### PR TITLE
Fix:RepositoryBlobStorageBuilder.cs to fix BlobContainerClient initialization with Managed Identities

### DIFF
--- a/src/Repository/RepositoryFramework.Infrastructures/RepositoryFramework.Infrastructure.Azure.Storage.Blob/Builder/RepositoryBlobStorageBuilder.cs
+++ b/src/Repository/RepositoryFramework.Infrastructures/RepositoryFramework.Infrastructure.Azure.Storage.Blob/Builder/RepositoryBlobStorageBuilder.cs
@@ -20,15 +20,17 @@ namespace RepositoryFramework.Infrastructure.Azure.Storage.Blob
                     Settings.ContainerName?.ToLower() ?? Settings.ModelType.Name.ToLower(), Settings.ClientOptions);
                 return AddAsync(containerClient);
             }
-            else if (Settings.EndpointUri != null)
+
+            if (Settings.EndpointUri != null)
             {
                 TokenCredential defaultCredential =
-                    Settings.ManagedIdentityClientId == null ?
-                    new DefaultAzureCredential()
-                    : new ManagedIdentityCredential(Settings.ManagedIdentityClientId);
+                    Settings.ManagedIdentityClientId == null
+                        ? new DefaultAzureCredential()
+                        : new ManagedIdentityCredential(Settings.ManagedIdentityClientId);
                 var containerClient = new BlobContainerClient(Settings.EndpointUri, defaultCredential, Settings.ClientOptions);
                 return AddAsync(containerClient);
             }
+            
             throw new ArgumentException($"Wrong installation for {Settings.ModelType.Name} model in your repository blob storage. Use managed identity or a connection string.");
         }
         private async Task<Func<IServiceProvider, BlobContainerClientWrapper>> AddAsync(BlobContainerClient containerClient)


### PR DESCRIPTION
- Reorganized if-else statements for better flow
- Simplified conditional statement for credential instantiation
- Added container name for initialization with managed identity, it was missing
- Run tests and thery are passing, they should be ok and backwards compatibility should be mantained

Don't know how to properly test with my project so i'll do my best to described the changes:

Before the changes if i wanted to add a BlobContainerClient to DI using a managedIdentity i would have done it like so:

```c#
builder.Services.AddRepository<Example, string>(builder =>
    {
        builder.WithBlobStorage(builder =>
        {
            builder.Settings.EndpointUri = new Uri("https://account.blob.core.windows.net/<container-name>");
            builder.Settings.ManagedIdentityClientId = "clientId";
            builder.Settings.ContainerName = "container-name";
        });
    });
```

> Notice that i have to include the container name in the url otherwise it will not be taken over with the setting, it may be error prone and not easy to understand at first glance.

After the fix it's like this:

```c#
builder.Services.AddRepository<Example, string>(builder =>
    {
        builder.WithBlobStorage(builder =>
        {
            builder.Settings.EndpointUri = new Uri("https://account.blob.core.windows.net");
            builder.Settings.ManagedIdentityClientId = "clientId";
            builder.Settings.ContainerName = "container-name";
        });
    });
```

> the container name will be added after, if not present instead of throwing an exception i will us 'example' (it uses typeof) as the container name.

This example was made using blob storage, it's the same using table storage.