### PR TITLE
feat: add with endpoint method

### DIFF
--- a/src/AI/Rystem.PlayFramework/Api/Models/PlayFrameworkDiscoveryResponse.cs
+++ b/src/AI/Rystem.PlayFramework/Api/Models/PlayFrameworkDiscoveryResponse.cs
@@ -31,6 +31,11 @@ public sealed class PlayFrameworkDiscoveryResponse
     public List<PlayFrameworkToolSourceInfo> McpServers { get; set; } = [];
 
     /// <summary>
+    /// HTTP endpoint tools backed by typed HttpClients.
+    /// </summary>
+    public List<PlayFrameworkToolSourceInfo> Endpoints { get; set; } = [];
+
+    /// <summary>
     /// Tools that do not belong to the standard source buckets.
     /// </summary>
     public List<PlayFrameworkToolInfo> Others { get; set; } = [];

--- a/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
+++ b/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
@@ -402,6 +402,7 @@ public static class WebApplicationExtensions
         var services = new Dictionary<string, PlayFrameworkToolSourceInfo>(StringComparer.OrdinalIgnoreCase);
         var clients = new Dictionary<string, PlayFrameworkToolSourceInfo>(StringComparer.OrdinalIgnoreCase);
         var mcpServers = new Dictionary<string, PlayFrameworkToolSourceInfo>(StringComparer.OrdinalIgnoreCase);
+        var endpoints = new Dictionary<string, PlayFrameworkToolSourceInfo>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var scene in sceneFactory.Scenes)
         {
@@ -415,7 +416,7 @@ public static class WebApplicationExtensions
             {
                 var toolInfo = BuildSceneToolInfo(scene.Name, tool);
                 sceneInfo.Tools.Add(toolInfo);
-                AddToolToResponse(response, services, clients, toolInfo);
+                AddToolToResponse(response, services, clients, endpoints, toolInfo);
             }
 
             foreach (var mcpReference in scene.McpServerReferences)
@@ -458,6 +459,7 @@ public static class WebApplicationExtensions
         response.Services = [.. services.Values.OrderBy(x => x.Name)];
         response.Clients = [.. clients.Values.OrderBy(x => x.Name)];
         response.McpServers = [.. mcpServers.Values.OrderBy(x => x.Name)];
+        response.Endpoints = [.. endpoints.Values.OrderBy(x => x.Name)];
         response.Scenes = [.. response.Scenes.OrderBy(x => x.Name)];
         response.Others = [.. response.Others.OrderBy(x => x.SceneName).ThenBy(x => x.ToolName)];
 
@@ -494,6 +496,7 @@ public static class WebApplicationExtensions
         PlayFrameworkDiscoveryResponse response,
         Dictionary<string, PlayFrameworkToolSourceInfo> services,
         Dictionary<string, PlayFrameworkToolSourceInfo> clients,
+        Dictionary<string, PlayFrameworkToolSourceInfo> endpoints,
         PlayFrameworkToolInfo tool)
     {
         switch (tool.SourceType)
@@ -503,6 +506,9 @@ public static class WebApplicationExtensions
                 break;
             case PlayFrameworkToolSourceType.Client:
                 AddToolIfMissing(GetOrCreateSource(clients, tool.SourceName ?? "client", PlayFrameworkToolSourceType.Client).Tools, tool);
+                break;
+            case PlayFrameworkToolSourceType.Endpoint:
+                AddToolIfMissing(GetOrCreateSource(endpoints, tool.SourceName ?? "unknown", PlayFrameworkToolSourceType.Endpoint).Tools, tool);
                 break;
             default:
                 AddToolIfMissing(response.Others, tool);

--- a/src/AI/Rystem.PlayFramework/Builder/EndpointToolBuilder.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/EndpointToolBuilder.cs
@@ -1,0 +1,172 @@
+using Rystem.PlayFramework.Helpers;
+
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Builder for configuring HTTP endpoint tools for a specific typed client <typeparamref name="TClient"/>.
+/// Each call to <see cref="WithAction{TResponse}"/> or <see cref="WithAction{TRequest,TResponse}"/>
+/// registers one AI tool backed by an HTTP endpoint.
+/// </summary>
+/// <typeparam name="TClient">
+/// The marker type registered with <c>PlayFrameworkBuilder.WithHttpClient&lt;TClient&gt;()</c>.
+/// Used to resolve the named <see cref="System.Net.Http.IHttpClientFactory"/> client at runtime.
+/// </typeparam>
+public sealed class EndpointToolBuilder<TClient> where TClient : class
+{
+    private readonly SceneConfiguration _config;
+
+    internal EndpointToolBuilder(SceneConfiguration config)
+    {
+        _config = config;
+    }
+
+    /// <summary>
+    /// Registers an HTTP endpoint as an AI tool without a request body (GET, DELETE, HEAD, OPTIONS).
+    /// Route template placeholders (<c>{param}</c>) are automatically extracted as required parameters.
+    /// </summary>
+    /// <typeparam name="TResponse">Expected JSON response type.</typeparam>
+    /// <param name="toolName">Name exposed to the AI model.</param>
+    /// <param name="method">HTTP method (e.g. <see cref="HttpMethod.Get"/>).</param>
+    /// <param name="routeTemplate">
+    /// Route relative to the base address, e.g. <c>/orders/{orderId}</c>.
+    /// Absolute URLs are also supported.
+    /// </param>
+    /// <param name="description">Description for the AI model.</param>
+    /// <returns>An <see cref="EndpointActionBuilder"/> for adding optional query parameters.</returns>
+    public EndpointActionBuilder WithAction<TResponse>(
+        string toolName,
+        HttpMethod method,
+        string routeTemplate,
+        string description)
+    {
+        var config = new EndpointToolConfiguration
+        {
+            ClientType = typeof(TClient),
+            ToolName = ToolNameNormalizer.Normalize(toolName),
+            Description = description,
+            HttpMethod = method,
+            RouteTemplate = routeTemplate,
+            RequestBodyType = null,
+            ResponseType = typeof(TResponse)
+        };
+
+        _config.EndpointTools.Add(config);
+        return new EndpointActionBuilder(config);
+    }
+
+    /// <summary>
+    /// Registers an HTTP endpoint as an AI tool with a typed request body (POST, PUT, PATCH).
+    /// The public properties of <typeparamref name="TRequest"/> are exposed as tool parameters.
+    /// Route template placeholders (<c>{param}</c>) are automatically extracted as well.
+    /// </summary>
+    /// <typeparam name="TRequest">Type of the JSON request body.</typeparam>
+    /// <typeparam name="TResponse">Expected JSON response type.</typeparam>
+    /// <param name="toolName">Name exposed to the AI model.</param>
+    /// <param name="method">HTTP method (e.g. <see cref="HttpMethod.Post"/>).</param>
+    /// <param name="routeTemplate">
+    /// Route relative to the base address, e.g. <c>/orders/{orderId}</c>.
+    /// </param>
+    /// <param name="description">Description for the AI model.</param>
+    /// <returns>An <see cref="EndpointActionBuilder"/> for adding optional query parameters.</returns>
+    public EndpointActionBuilder WithAction<TRequest, TResponse>(
+        string toolName,
+        HttpMethod method,
+        string routeTemplate,
+        string description)
+    {
+        var config = new EndpointToolConfiguration
+        {
+            ClientType = typeof(TClient),
+            ToolName = ToolNameNormalizer.Normalize(toolName),
+            Description = description,
+            HttpMethod = method,
+            RouteTemplate = routeTemplate,
+            RequestBodyType = typeof(TRequest),
+            ResponseType = typeof(TResponse)
+        };
+
+        _config.EndpointTools.Add(config);
+        return new EndpointActionBuilder(config);
+    }
+}
+
+/// <summary>
+/// Fluent builder for adding optional query-string parameters to an endpoint tool action.
+/// </summary>
+public sealed class EndpointActionBuilder
+{
+    private readonly EndpointToolConfiguration _config;
+
+    internal EndpointActionBuilder(EndpointToolConfiguration config)
+    {
+        _config = config;
+    }
+
+    /// <summary>
+    /// Adds a query-string parameter to the tool.
+    /// This parameter is exposed in the AI schema and appended as <c>?name=value</c> to the URL.
+    /// </summary>
+    /// <param name="name">Parameter name (used both in the AI schema and in the query string).</param>
+    /// <param name="description">Description for the AI model.</param>
+    /// <param name="type">
+    /// C# type of the parameter (default: <see cref="string"/>).
+    /// Used to generate the JSON Schema type.
+    /// </param>
+    /// <returns>This builder for chaining.</returns>
+    public EndpointActionBuilder WithParameter(string name, string description, Type? type = null)
+    {
+        _config.QueryParameters.Add(new EndpointParameterDefinition
+        {
+            Name = name,
+            Description = description,
+            Type = type ?? typeof(string)
+        });
+
+        return this;
+    }
+}
+
+/// <summary>
+/// Internal configuration for a single HTTP-endpoint tool.
+/// </summary>
+internal sealed class EndpointToolConfiguration
+{
+    /// <summary>Marker type for the typed <see cref="System.Net.Http.IHttpClientFactory"/> client.</summary>
+    public required Type ClientType { get; init; }
+
+    /// <summary>Normalized tool name exposed to the AI model.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>Description sent to the AI model.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>HTTP method (GET, POST, PUT, DELETE, PATCH, …).</summary>
+    public required HttpMethod HttpMethod { get; init; }
+
+    /// <summary>
+    /// Route template, e.g. <c>/orders/{orderId}</c>.
+    /// Placeholders in curly braces are extracted automatically as required AI parameters.
+    /// </summary>
+    public required string RouteTemplate { get; init; }
+
+    /// <summary>
+    /// Type of the JSON request body, or <c>null</c> for methods without a body.
+    /// </summary>
+    public Type? RequestBodyType { get; init; }
+
+    /// <summary>Type expected in the JSON response (used for deserialisation).</summary>
+    public required Type ResponseType { get; init; }
+
+    /// <summary>Query-string parameters declared via <see cref="EndpointActionBuilder.WithParameter"/>.</summary>
+    public List<EndpointParameterDefinition> QueryParameters { get; init; } = [];
+}
+
+/// <summary>
+/// Describes a single query-string parameter for an endpoint tool.
+/// </summary>
+internal sealed class EndpointParameterDefinition
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public Type Type { get; init; } = typeof(string);
+}

--- a/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder_HttpClient.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder_HttpClient.cs
@@ -8,41 +8,62 @@ namespace Rystem.PlayFramework;
 public static class PlayFrameworkBuilder_HttpClient
 {
     /// <summary>
-    /// Registers a typed HTTP client via IHttpClientFactory.
-    /// <typeparamref name="TClient"/> is a marker type (typically an empty interface)
-    /// used as the named-client key: <c>typeof(TClient).Name</c>.
-    /// The <paramref name="configure"/> delegate exposes the standard
-    /// <see cref="IHttpClientBuilder"/> so you can set base address,
-    /// add <see cref="System.Net.Http.DelegatingHandler"/>s, Polly resilience, etc.
+    /// Registers a typed HTTP client configuring the <see cref="System.Net.Http.HttpClient"/>
+    /// directly (base address, timeout, headers, etc.).
     /// </summary>
     /// <typeparam name="TClient">
     /// Marker type used as the factory key.
     /// Must be the same type passed to <c>SceneBuilder.WithEndpoint&lt;TClient&gt;()</c>.
     /// </typeparam>
-    /// <param name="builder">The PlayFramework builder.</param>
-    /// <param name="configure">Action that configures the underlying <see cref="IHttpClientBuilder"/>.</param>
-    /// <returns>The builder for chaining.</returns>
     /// <example>
     /// <code>
-    /// builder.WithHttpClient&lt;IOrderServiceClient&gt;(http =&gt;
+    /// builder.WithHttpClient&lt;IOrderServiceClient&gt;(c =&gt;
     /// {
-    ///     http.ConfigureHttpClient(c =&gt;
-    ///     {
-    ///         c.BaseAddress = new Uri("http://order-service:5001/api");
-    ///         c.Timeout = TimeSpan.FromSeconds(30);
-    ///     });
-    ///     http.AddHttpMessageHandler&lt;BearerTokenHandler&gt;();
-    ///     http.AddStandardResilienceHandler();
+    ///     c.BaseAddress = new Uri("http://order-service:5001/api");
+    ///     c.Timeout = TimeSpan.FromSeconds(30);
     /// });
     /// </code>
     /// </example>
     public static PlayFrameworkBuilder WithHttpClient<TClient>(
         this PlayFrameworkBuilder builder,
-        Action<IHttpClientBuilder> configure)
+        Action<HttpClient> configureClient)
         where TClient : class
     {
-        var httpClientBuilder = builder.Services.AddHttpClient(typeof(TClient).Name);
-        configure(httpClientBuilder);
+        builder.Services.AddHttpClient(typeof(TClient).Name, configureClient);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers a typed HTTP client configuring both the <see cref="System.Net.Http.HttpClient"/>
+    /// (base address, timeout, headers) and the <see cref="IHttpClientBuilder"/>
+    /// (message handlers, Polly resilience, etc.).
+    /// </summary>
+    /// <typeparam name="TClient">
+    /// Marker type used as the factory key.
+    /// Must be the same type passed to <c>SceneBuilder.WithEndpoint&lt;TClient&gt;()</c>.
+    /// </typeparam>
+    /// <param name="configureClient">Configures the <see cref="System.Net.Http.HttpClient"/> instance.</param>
+    /// <param name="configureBuilder">Configures the <see cref="IHttpClientBuilder"/> (handlers, resilience, etc.).</param>
+    /// <example>
+    /// <code>
+    /// builder.WithHttpClient&lt;IOrderServiceClient&gt;(
+    ///     c =&gt;
+    ///     {
+    ///         c.BaseAddress = new Uri("http://order-service:5001/api");
+    ///         c.Timeout = TimeSpan.FromSeconds(30);
+    ///     },
+    ///     b =&gt; b.AddHttpMessageHandler&lt;BearerTokenHandler&gt;()
+    ///           .AddStandardResilienceHandler());
+    /// </code>
+    /// </example>
+    public static PlayFrameworkBuilder WithHttpClient<TClient>(
+        this PlayFrameworkBuilder builder,
+        Action<HttpClient> configureClient,
+        Action<IHttpClientBuilder> configureBuilder)
+        where TClient : class
+    {
+        var httpClientBuilder = builder.Services.AddHttpClient(typeof(TClient).Name, configureClient);
+        configureBuilder(httpClientBuilder);
         return builder;
     }
 }

--- a/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder_HttpClient.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder_HttpClient.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Extension methods for registering typed HTTP clients on PlayFrameworkBuilder.
+/// </summary>
+public static class PlayFrameworkBuilder_HttpClient
+{
+    /// <summary>
+    /// Registers a typed HTTP client via IHttpClientFactory.
+    /// <typeparamref name="TClient"/> is a marker type (typically an empty interface)
+    /// used as the named-client key: <c>typeof(TClient).Name</c>.
+    /// The <paramref name="configure"/> delegate exposes the standard
+    /// <see cref="IHttpClientBuilder"/> so you can set base address,
+    /// add <see cref="System.Net.Http.DelegatingHandler"/>s, Polly resilience, etc.
+    /// </summary>
+    /// <typeparam name="TClient">
+    /// Marker type used as the factory key.
+    /// Must be the same type passed to <c>SceneBuilder.WithEndpoint&lt;TClient&gt;()</c>.
+    /// </typeparam>
+    /// <param name="builder">The PlayFramework builder.</param>
+    /// <param name="configure">Action that configures the underlying <see cref="IHttpClientBuilder"/>.</param>
+    /// <returns>The builder for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// builder.WithHttpClient&lt;IOrderServiceClient&gt;(http =&gt;
+    /// {
+    ///     http.ConfigureHttpClient(c =&gt;
+    ///     {
+    ///         c.BaseAddress = new Uri("http://order-service:5001/api");
+    ///         c.Timeout = TimeSpan.FromSeconds(30);
+    ///     });
+    ///     http.AddHttpMessageHandler&lt;BearerTokenHandler&gt;();
+    ///     http.AddStandardResilienceHandler();
+    /// });
+    /// </code>
+    /// </example>
+    public static PlayFrameworkBuilder WithHttpClient<TClient>(
+        this PlayFrameworkBuilder builder,
+        Action<IHttpClientBuilder> configure)
+        where TClient : class
+    {
+        var httpClientBuilder = builder.Services.AddHttpClient(typeof(TClient).Name);
+        configure(httpClientBuilder);
+        return builder;
+    }
+}

--- a/src/AI/Rystem.PlayFramework/Builder/SceneBuilder.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/SceneBuilder.cs
@@ -19,6 +19,19 @@ public sealed class SceneBuilder
     }
 
     /// <summary>
+    /// Adds HTTP endpoint tools backed by a typed <see cref="System.Net.Http.HttpClient"/>.
+    /// The client must have been registered with <c>PlayFrameworkBuilder.WithHttpClient&lt;TClient&gt;()</c>.
+    /// </summary>
+    /// <typeparam name="TClient">Marker type for the named HttpClient.</typeparam>
+    /// <param name="configure">Action to configure the endpoint actions.</param>
+    public SceneBuilder WithEndpoint<TClient>(Action<EndpointToolBuilder<TClient>> configure) where TClient : class
+    {
+        var builder = new EndpointToolBuilder<TClient>(_config);
+        configure(builder);
+        return this;
+    }
+
+    /// <summary>
     /// Adds service methods as tools.
     /// </summary>
     public SceneBuilder WithService<TService>(Action<ServiceToolBuilder<TService>> configure) where TService : class
@@ -109,6 +122,7 @@ internal sealed class SceneConfiguration
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public List<ServiceToolConfiguration> ServiceTools { get; set; } = [];
+    public List<EndpointToolConfiguration> EndpointTools { get; set; } = [];
     public List<ActorConfiguration> Actors { get; set; } = [];
     public List<McpServerReference> McpServerReferences { get; set; } = [];
 

--- a/src/AI/Rystem.PlayFramework/Docs/SPEC-WithEndpoint.md
+++ b/src/AI/Rystem.PlayFramework/Docs/SPEC-WithEndpoint.md
@@ -1,0 +1,1035 @@
+# Specifica: `WithEndpoint<TClient>()` — Chiamate HTTP esterne come tool AI
+
+> **Versioni**
+> - **v1.0** — Configurazione manuale degli endpoint tramite `WithAction` _(questa release)_
+> - **v1.1** — Auto-generazione dei tool da una specifica OpenAPI _(release successiva)_
+
+---
+
+## v1.0 — Configurazione manuale con `WithAction`
+
+### Obiettivo
+
+Permettere a una scena del PlayFramework di invocare endpoint HTTP esterni come tool AI, con supporto completo per:
+
+- URL assoluti (`http://localhost/Controller/Action`)
+- Route relative (`/Controller/Action`) quando configurato un `IHttpClientFactory` con base address
+- DelegatingHandler per autorizzazione, retry, circuit breaker
+- Resiliency tramite le estensioni standard .NET (Polly, `AddStandardResilienceHandler()`)
+- Serializzazione/deserializzazione custom tramite `IJsonService`
+
+---
+
+### Architettura generale
+
+La feature si divide in **due livelli**:
+
+| Livello | Dove | Responsabilità |
+|---------|------|----------------|
+| **Infrastruttura HTTP** | `PlayFrameworkBuilder` | Registra l'`HttpClient` tipizzato con base URL, DelegatingHandler, policy di resiliency |
+| **Configurazione tool** | `SceneBuilder` | Definisce quali endpoint esporre come tool AI nella scena, con nome, route, HTTP method, parametri |
+
+Questa separazione garantisce che:
+- La configurazione dell'infrastruttura HTTP (auth, retry, timeout) vive in un unico punto
+- Più scene possono riutilizzare lo stesso client HTTP configurato
+- Ogni scena espone solo gli endpoint rilevanti per il proprio contesto
+
+---
+
+### API pubblica
+
+#### 1. Registrazione HttpClient — `PlayFrameworkBuilder`
+
+```csharp
+// File: Builder/PlayFrameworkBuilder_HttpClient.cs (partial class)
+
+public sealed partial class PlayFrameworkBuilder
+{
+    /// <summary>
+    /// Registra un HttpClient tipizzato tramite IHttpClientFactory.
+    /// TClient è un tipo marker (interface vuota) usato come chiave per il named client.
+    /// Il configure espone IHttpClientBuilder standard .NET per configurare
+    /// base address, DelegatingHandler, Polly, timeout, ecc.
+    /// </summary>
+    public PlayFrameworkBuilder WithHttpClient<TClient>(Action<IHttpClientBuilder> configure)
+        where TClient : class;
+}
+```
+
+**Esempio d'uso:**
+
+```csharp
+builder.WithHttpClient<IOrderServiceClient>(httpBuilder =>
+{
+    httpBuilder.ConfigureHttpClient(client =>
+    {
+        client.BaseAddress = new Uri("http://localhost:5001/api");
+        client.Timeout = TimeSpan.FromSeconds(30);
+    });
+
+    // DelegatingHandler per autenticazione Bearer
+    httpBuilder.AddHttpMessageHandler<BearerTokenHandler>();
+
+    // Resiliency con Polly (Microsoft.Extensions.Http.Resilience)
+    httpBuilder.AddStandardResilienceHandler();
+});
+```
+
+**Dettagli implementativi:**
+- Internamente chiama `_services.AddHttpClient(typeof(TClient).Name)` e passa l'`IHttpClientBuilder` al delegate
+- `TClient` è un **tipo marker** (tipicamente un'interface vuota): serve solo come chiave per risolvere il client corretto a runtime via `IHttpClientFactory.CreateClient(typeof(TClient).Name)`
+- L'utente ha accesso a **tutte** le estensioni standard di `IHttpClientBuilder`: `AddHttpMessageHandler`, `ConfigurePrimaryHttpMessageHandler`, `SetHandlerLifetime`, `AddStandardResilienceHandler`, ecc.
+
+---
+
+#### 2. Configurazione endpoint nella scena — `SceneBuilder`
+
+```csharp
+// File: Builder/SceneBuilder.cs (metodo aggiuntivo)
+
+public sealed class SceneBuilder
+{
+    /// <summary>
+    /// Aggiunge tool che invocano endpoint HTTP esterni.
+    /// TClient deve essere un tipo precedentemente registrato con
+    /// PlayFrameworkBuilder.WithHttpClient<TClient>().
+    /// </summary>
+    public SceneBuilder WithEndpoint<TClient>(Action<EndpointToolBuilder<TClient>> configure)
+        where TClient : class;
+}
+```
+
+**Esempio d'uso:**
+
+```csharp
+scene.WithEndpoint<IOrderServiceClient>(endpoint =>
+{
+    // GET senza body — parametri estratti dalla route template
+    endpoint.WithAction<OrderDto>(
+        "GetOrder",
+        HttpMethod.Get,
+        "/orders/{orderId}",
+        "Recupera un ordine per ID");
+
+    // GET con query parameters aggiuntivi
+    endpoint.WithAction<List<OrderDto>>(
+        "SearchOrders",
+        HttpMethod.Get,
+        "/orders",
+        "Cerca ordini con filtri")
+        .WithParameter("status", "Stato dell'ordine (pending, completed, cancelled)", typeof(string))
+        .WithParameter("fromDate", "Data inizio ricerca (ISO 8601)", typeof(DateTime));
+
+    // POST con body tipizzato
+    endpoint.WithAction<CreateOrderRequest, OrderDto>(
+        "CreateOrder",
+        HttpMethod.Post,
+        "/orders",
+        "Crea un nuovo ordine");
+
+    // PUT con body tipizzato
+    endpoint.WithAction<UpdateOrderRequest, OrderDto>(
+        "UpdateOrder",
+        HttpMethod.Put,
+        "/orders/{orderId}",
+        "Aggiorna un ordine esistente");
+
+    // DELETE senza body
+    endpoint.WithAction<bool>(
+        "DeleteOrder",
+        HttpMethod.Delete,
+        "/orders/{orderId}",
+        "Elimina un ordine");
+});
+```
+
+---
+
+#### 3. `EndpointToolBuilder<TClient>` — Builder per i singoli tool
+
+```csharp
+// File: Builder/EndpointToolBuilder.cs
+
+public sealed class EndpointToolBuilder<TClient> where TClient : class
+{
+    /// <summary>
+    /// Aggiunge un tool HTTP senza request body (GET, DELETE, HEAD, OPTIONS).
+    /// I parametri della route template ({param}) vengono estratti automaticamente.
+    /// TResponse è il tipo atteso nella risposta JSON.
+    /// </summary>
+    public EndpointActionBuilder WithAction<TResponse>(
+        string toolName,
+        HttpMethod method,
+        string routeTemplate,
+        string description);
+
+    /// <summary>
+    /// Aggiunge un tool HTTP con request body (POST, PUT, PATCH).
+    /// TRequest definisce lo schema del body JSON inviato.
+    /// TResponse è il tipo atteso nella risposta JSON.
+    /// I parametri della route template ({param}) vengono estratti automaticamente.
+    /// </summary>
+    public EndpointActionBuilder WithAction<TRequest, TResponse>(
+        string toolName,
+        HttpMethod method,
+        string routeTemplate,
+        string description);
+}
+
+/// <summary>
+/// Builder fluent per aggiungere parametri aggiuntivi (query params) a un'azione endpoint.
+/// </summary>
+public sealed class EndpointActionBuilder
+{
+    /// <summary>
+    /// Aggiunge un parametro query string al tool.
+    /// Questo parametro viene esposto nello schema AI e passato come ?key=value nella request.
+    /// </summary>
+    /// <param name="name">Nome del parametro (usato sia nello schema AI sia nella query string).</param>
+    /// <param name="description">Descrizione per l'AI.</param>
+    /// <param name="type">Tipo C# del parametro (default: string). Usato per la generazione dello schema JSON.</param>
+    public EndpointActionBuilder WithParameter(string name, string description, Type? type = null);
+}
+```
+
+---
+
+### Modello di configurazione interno
+
+#### `EndpointToolConfiguration`
+
+```csharp
+// File: Builder/EndpointToolBuilder.cs (o file separato)
+
+internal sealed class EndpointToolConfiguration
+{
+    /// <summary>
+    /// Tipo marker del client HTTP (chiave per IHttpClientFactory).
+    /// </summary>
+    public required Type ClientType { get; init; }
+
+    /// <summary>
+    /// Nome del tool esposto all'AI.
+    /// </summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>
+    /// Descrizione del tool per l'AI.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Metodo HTTP (GET, POST, PUT, DELETE, PATCH).
+    /// </summary>
+    public required HttpMethod HttpMethod { get; init; }
+
+    /// <summary>
+    /// Route template con placeholder: es. "/orders/{orderId}".
+    /// I {param} vengono estratti automaticamente come parametri del tool.
+    /// </summary>
+    public required string RouteTemplate { get; init; }
+
+    /// <summary>
+    /// Tipo del request body (null se nessun body, es. per GET/DELETE).
+    /// Lo schema JSON dell'AI viene generato da questo tipo.
+    /// </summary>
+    public Type? RequestBodyType { get; init; }
+
+    /// <summary>
+    /// Tipo della response attesa (per deserializzazione).
+    /// </summary>
+    public required Type ResponseType { get; init; }
+
+    /// <summary>
+    /// Parametri aggiuntivi (query string) dichiarati via WithParameter().
+    /// </summary>
+    public List<EndpointParameterDefinition> QueryParameters { get; init; } = [];
+}
+
+internal sealed class EndpointParameterDefinition
+{
+    public required string Name { get; init; }
+    public required string Description { get; init; }
+    public Type Type { get; init; } = typeof(string);
+}
+```
+
+#### Aggiunta a `SceneConfiguration`
+
+```csharp
+internal sealed class SceneConfiguration
+{
+    // ... campi esistenti ...
+
+    /// <summary>
+    /// Tool basati su endpoint HTTP esterni registrati via WithEndpoint<TClient>().
+    /// </summary>
+    public List<EndpointToolConfiguration> EndpointTools { get; set; } = [];
+}
+```
+
+---
+
+### Implementazione runtime — `EndpointHttpTool`
+
+#### Classe
+
+```csharp
+// File: Services/Tools/EndpointHttpTool.cs
+
+internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
+{
+    // Implementa ISceneTool
+    public string Name { get; }
+    public string Description { get; }
+    public AITool ToolDescription { get; }
+
+    // Implementa ISceneToolMetadata
+    public PlayFrameworkToolSourceType SourceType => PlayFrameworkToolSourceType.Endpoint;
+    public string? SourceName => _config.ClientType.Name;
+    public string? MemberName => _config.RouteTemplate;
+    public bool IsCommand => false;
+    public string? JsonSchema => null;
+}
+```
+
+#### Costruzione dello schema AI
+
+Lo schema JSON esposto al modello AI viene costruito nel costruttore di `EndpointHttpTool`:
+
+1. **Parametri route**: estratti dalla route template via regex `\{(\w+)\}` → diventano proprietà `string` nello schema
+2. **Query parameters**: dichiarati via `.WithParameter()` → proprietà nello schema con tipo specificato
+3. **Body (TRequest)**: se presente, le proprietà di `TRequest` vengono aggiunte allo schema tramite `AIJsonUtilities.CreateParametersJsonSchema(typeof(TRequest))`
+
+Lo schema risultante viene passato a `AIFunctionFactory.CreateDeclaration(name, description, schema)` per generare l'`AITool`.
+
+**Esempio di schema generato per `GetOrder`:**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "orderId": { "type": "string", "description": "Route parameter: orderId" }
+  },
+  "required": ["orderId"]
+}
+```
+
+**Esempio di schema generato per `CreateOrder` (con body `CreateOrderRequest`):**
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "customerName": { "type": "string" },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/OrderItem" }
+    },
+    "shippingAddress": { "type": "string" }
+  },
+  "required": ["customerName", "items"]
+}
+```
+
+#### Esecuzione (`ExecuteAsync`)
+
+```csharp
+public async Task<object?> ExecuteAsync(
+    string arguments,
+    SceneContext context,
+    CancellationToken cancellationToken)
+{
+    // 1. Risolvere IHttpClientFactory dal service provider
+    var factory = context.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+    var client = factory.CreateClient(_config.ClientType.Name);
+
+    // 2. Deserializzare gli argomenti JSON dall'AI
+    var argsDict = _jsonService.Deserialize<Dictionary<string, JsonElement>>(arguments);
+
+    // 3. Costruire l'URL:
+    //    a) Sostituire i {param} nella route template con i valori ricevuti
+    //    b) Aggiungere i query parameters come ?key=value
+    var url = BuildUrl(argsDict);
+
+    // 4. Creare la HttpRequestMessage
+    var request = new HttpRequestMessage(_config.HttpMethod, url);
+
+    // 5. Se c'è un body (TRequest != null), serializzare e impostare come content
+    if (_config.RequestBodyType != null)
+    {
+        var body = ExtractBodyFromArguments(argsDict);
+        request.Content = new StringContent(
+            _jsonService.Serialize(body, _config.RequestBodyType),
+            Encoding.UTF8,
+            "application/json");
+    }
+
+    // 6. Inviare la request
+    var response = await client.SendAsync(request, cancellationToken);
+
+    // 7. Leggere il body della response
+    var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+    // 8. Tentare la deserializzazione di TResponse
+    object? deserializedBody;
+    try
+    {
+        deserializedBody = _jsonService.Deserialize(responseBody, _config.ResponseType);
+    }
+    catch
+    {
+        // Fallback: restituire il body come stringa
+        deserializedBody = responseBody;
+    }
+
+    // 9. Restituire risultato con status code + body
+    return new EndpointHttpResponse
+    {
+        StatusCode = (int)response.StatusCode,
+        Body = deserializedBody
+    };
+}
+```
+
+#### Costruzione URL
+
+```csharp
+private string BuildUrl(Dictionary<string, JsonElement>? argsDict)
+{
+    var url = _config.RouteTemplate;
+
+    if (argsDict == null)
+        return url;
+
+    // Sostituzione parametri route: /orders/{orderId} → /orders/abc-123
+    foreach (var routeParam in _routeParameters)
+    {
+        if (argsDict.TryGetValue(routeParam, out var value))
+        {
+            url = url.Replace($"{{{routeParam}}}", value.GetString() ?? value.GetRawText());
+        }
+    }
+
+    // Aggiunta query parameters
+    var queryParams = _config.QueryParameters
+        .Where(qp => argsDict.ContainsKey(qp.Name))
+        .Select(qp => $"{qp.Name}={Uri.EscapeDataString(argsDict[qp.Name].GetString() ?? argsDict[qp.Name].GetRawText())}");
+
+    var queryString = string.Join("&", queryParams);
+    if (!string.IsNullOrEmpty(queryString))
+        url += $"?{queryString}";
+
+    return url;
+}
+```
+
+#### Tipo di risposta restituito all'AI
+
+```csharp
+/// <summary>
+/// Risposta di un endpoint HTTP restituita all'AI.
+/// Include lo status code per permettere all'AI di reagire a errori (400, 422, 500).
+/// </summary>
+internal sealed class EndpointHttpResponse
+{
+    public int StatusCode { get; init; }
+    public object? Body { get; init; }
+}
+```
+
+---
+
+### Integrazione in `Scene.cs`
+
+```csharp
+internal sealed class Scene : IScene
+{
+    public Scene(SceneConfiguration configuration, IJsonService? jsonService = null)
+    {
+        // ... codice esistente per serviceTools e clientTools ...
+
+        // Creazione tool da endpoint HTTP
+        var endpointTools = _config.EndpointTools
+            .Select(et => new EndpointHttpTool(et, jsonService))
+            .ToList();
+
+        // Combinazione di tutti i tool
+        Tools = [.. serviceTools];
+        Tools.AddRange(clientTools);
+        Tools.AddRange(endpointTools);  // ← AGGIUNTA
+        AiTools = [.. Tools.Select(x => x.ToolDescription)];
+
+        // ... resto del costruttore ...
+    }
+}
+```
+
+---
+
+### Enum `PlayFrameworkToolSourceType`
+
+```csharp
+public enum PlayFrameworkToolSourceType
+{
+    Service,
+    Client,
+    Mcp,
+    Rag,
+    WebSearch,
+    Endpoint  // ← NUOVO VALORE
+}
+```
+
+---
+
+### File coinvolti v1.0 — Riepilogo
+
+| File | Azione | Contenuto |
+|------|--------|-----------|
+| `Builder/PlayFrameworkBuilder_HttpClient.cs` | **Nuovo** | Partial class con `WithHttpClient<TClient>()` |
+| `Builder/EndpointToolBuilder.cs` | **Nuovo** | `EndpointToolBuilder<TClient>`, `EndpointActionBuilder`, `EndpointToolConfiguration`, `EndpointParameterDefinition` |
+| `Services/Tools/EndpointHttpTool.cs` | **Nuovo** | Implementazione `ISceneTool` + `ISceneToolMetadata` per chiamate HTTP |
+| `Builder/SceneBuilder.cs` | **Modifica** | Aggiunta metodo `WithEndpoint<TClient>()` + campo `EndpointTools` in `SceneConfiguration` |
+| `Services/Scenes/Scene.cs` | **Modifica** | Istanziazione `EndpointHttpTool` dalla configurazione |
+| Enum `PlayFrameworkToolSourceType` | **Modifica** | Aggiunta valore `Endpoint` |
+
+---
+
+### Esempio completo end-to-end v1.0
+
+```csharp
+// === Program.cs / Startup ===
+
+// 1. Tipo marker per il client (interface vuota)
+public interface IOrderServiceClient { }
+
+// 2. DelegatingHandler per autenticazione
+public class BearerTokenHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken ct)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "...");
+        return await base.SendAsync(request, ct);
+    }
+}
+
+// 3. Configurazione PlayFramework
+services.AddPlayFramework(builder =>
+{
+    // Registrazione client HTTP con auth + resiliency
+    builder.WithHttpClient<IOrderServiceClient>(http =>
+    {
+        http.ConfigureHttpClient(c =>
+        {
+            c.BaseAddress = new Uri("http://order-service:5001/api");
+            c.DefaultRequestHeaders.Add("X-Api-Version", "2");
+        });
+        http.AddHttpMessageHandler<BearerTokenHandler>();
+        http.AddStandardResilienceHandler();
+    });
+
+    // Configurazione scena
+    builder.AddScene("OrderManagement", "Gestione ordini", scene =>
+    {
+        scene.WithEndpoint<IOrderServiceClient>(endpoint =>
+        {
+            endpoint.WithAction<OrderDto>(
+                "GetOrder", HttpMethod.Get, "/orders/{orderId}",
+                "Recupera i dettagli di un ordine dato il suo ID");
+
+            endpoint.WithAction<List<OrderSummaryDto>>(
+                "ListOrders", HttpMethod.Get, "/orders",
+                "Elenca gli ordini con filtri opzionali")
+                .WithParameter("status", "Filtra per stato: pending, shipped, delivered", typeof(string))
+                .WithParameter("customerId", "Filtra per ID cliente", typeof(Guid));
+
+            endpoint.WithAction<CreateOrderRequest, OrderDto>(
+                "CreateOrder", HttpMethod.Post, "/orders",
+                "Crea un nuovo ordine con gli articoli specificati");
+
+            endpoint.WithAction<UpdateOrderRequest, OrderDto>(
+                "UpdateOrder", HttpMethod.Put, "/orders/{orderId}",
+                "Aggiorna un ordine esistente");
+
+            endpoint.WithAction<bool>(
+                "CancelOrder", HttpMethod.Delete, "/orders/{orderId}",
+                "Annulla un ordine (se non ancora spedito)");
+        });
+    });
+});
+```
+
+---
+
+### Decisioni di design v1.0
+
+| Decisione | Scelta | Motivazione |
+|-----------|--------|-------------|
+| Nome metodo SceneBuilder | `WithEndpoint<TClient>()` | Coerente con `WithService<TService>()`, generico per typed client |
+| Ruolo di TClient | Solo marker per IHttpClientFactory | Nessuna reflection su metodi, massima semplicità |
+| Registrazione HttpClient | Su `PlayFrameworkBuilder` separatamente | Separazione infrastruttura vs configurazione tool |
+| Esposizione IHttpClientBuilder | Direttamente al configure | Accesso completo all'ecosistema .NET (Polly, handler, ecc.) |
+| Base URL | Dentro `ConfigureHttpClient()` su IHttpClientBuilder | Standard .NET, nessuna API custom necessaria |
+| Overload WithAction | `WithAction<TResponse>` (no body) + `WithAction<TRequest, TResponse>` (con body) | API pulita, TRequest nullable internamente |
+| Parametri route | Parsing automatico da template `{param}` | Nessuna configurazione manuale per parametri ovvi |
+| Query parameters | `.WithParameter()` esplicito | Necessario perché non deducibili dalla route |
+| Schema AI | `AIFunctionFactory.CreateDeclaration()` con schema costruito | Nessun MethodInfo disponibile per endpoint HTTP |
+| Risoluzione HttpClient a runtime | Da `context.ServiceProvider` in ExecuteAsync | Stesso pattern di ServiceMethodTool per servizi |
+| Gestione risposta HTTP | Body + StatusCode senza EnsureSuccessStatusCode | Anche errori 4xx/5xx contengono info utili per l'AI |
+| Deserializzazione | IJsonService con fallback a string raw | Supporta tipi custom (OneOf, ecc.) |
+| SourceType metadata | Nuovo valore `Endpoint` nella enum | Distinguibile da Service/Mcp/etc. nella discovery |
+| File organizzazione | Partial class + file separati per builder e tool | Coerente con pattern esistente nel codebase |
+
+---
+
+---
+
+## v1.1 — Auto-generazione tool da specifica OpenAPI
+
+### Obiettivo
+
+Estendere `WithEndpoint<TClient>()` per accettare una sorgente OpenAPI (URL remoto, file locale o stream) e generare automaticamente i tool AI da tutte le operazioni della spec, eliminando la necessità di chiamare `WithAction` manualmente per ogni endpoint. I tool generati dalla spec rimangono sovrascrivibili con `WithAction` espliciti.
+
+---
+
+### Principi chiave
+
+- **La spec è un shortcut, non un vincolo**: `WithAction` ha sempre precedenza sulla spec (match su `toolName == operationId`)
+- **Caricamento lazy**: la spec viene caricata e cachata al primo utilizzo della scena, non a startup. Questo rende compatibile l'uso con URL self-hosted (l'app serve la propria spec su `/openapi/v1.json`)
+- **servers[] della spec vengono ignorati**: la base URL è sempre gestita da `IHttpClientFactory` (configurata con `WithHttpClient<TClient>`). La spec fornisce solo i path relativi
+- **Nessuna dipendenza circolare**: il parser OpenAPI è una classe interna stateless; non è un servizio DI
+
+---
+
+### Nuova dipendenza NuGet
+
+```xml
+<!-- File: Rystem.PlayFramework.csproj -->
+<PackageReference Include="Microsoft.OpenApi.Readers" Version="2.x" />
+```
+
+`Microsoft.OpenApi.Readers` è il parser OpenAPI ufficiale Microsoft, già usato internamente da ASP.NET Core OpenAPI in .NET 10. Gestisce OpenAPI 3.x, risoluzione di `$ref`, `allOf`, `oneOf`, `anyOf`.
+
+---
+
+### Modifiche all'API pubblica
+
+#### `SceneBuilder` — nuovo overload di `WithEndpoint`
+
+```csharp
+public sealed class SceneBuilder
+{
+    // Overload v1.0 — INVARIATO
+    public SceneBuilder WithEndpoint<TClient>(Action<EndpointToolBuilder<TClient>> configure)
+        where TClient : class;
+
+    // Overload v1.1 — NUOVO
+    /// <summary>
+    /// Aggiunge tool generati automaticamente da una specifica OpenAPI.
+    /// La spec viene caricata lazily al primo utilizzo della scena.
+    /// I tool generati dalla spec possono essere sovrascritti con WithAction nel configure.
+    /// </summary>
+    /// <param name="specSource">
+    ///   Sorgente della spec: stringa URL (http/https), file path locale, Uri o Stream.
+    /// </param>
+    /// <param name="configure">
+    ///   Opzionale: filtri sulla spec e/o override di singole operazioni con WithAction.
+    /// </param>
+    public SceneBuilder WithEndpoint<TClient>(
+        AnyOf<string, Uri, Stream> specSource,
+        Action<EndpointToolBuilder<TClient>>? configure = null)
+        where TClient : class;
+}
+```
+
+#### `EndpointToolBuilder<TClient>` — nuovo metodo `FilterSpec`
+
+```csharp
+public sealed class EndpointToolBuilder<TClient> where TClient : class
+{
+    // Metodi v1.0 — INVARIATI
+    public EndpointActionBuilder WithAction<TResponse>(...);
+    public EndpointActionBuilder WithAction<TRequest, TResponse>(...);
+
+    // Metodo v1.1 — NUOVO
+    /// <summary>
+    /// Configura i filtri sulle operazioni della spec da includere come tool.
+    /// Di default, tutte le operazioni vengono incluse.
+    /// </summary>
+    public EndpointToolBuilder<TClient> FilterSpec(Action<OpenApiFilterSettings> configure);
+}
+```
+
+---
+
+### Nuovo tipo: `OpenApiFilterSettings`
+
+```csharp
+// File: Builder/OpenApiFilterSettings.cs
+
+/// <summary>
+/// Filtri applicati alle operazioni di una specifica OpenAPI
+/// per determinare quali diventano tool AI.
+/// Tutti i filtri sono OR tra elementi dello stesso tipo, AND tra tipi diversi.
+/// Di default (tutti vuoti) = includi tutto.
+/// </summary>
+public sealed class OpenApiFilterSettings
+{
+    /// <summary>
+    /// Include solo operazioni che hanno almeno uno di questi tag.
+    /// Esempio: ["Orders", "Customers"]
+    /// </summary>
+    public List<string> Tags { get; } = [];
+
+    /// <summary>
+    /// Include solo operazioni con uno di questi operationId.
+    /// Esempio: ["GetOrderById", "CreateOrder"]
+    /// </summary>
+    public List<string> OperationIds { get; } = [];
+
+    /// <summary>
+    /// Include solo operazioni il cui path inizia con uno di questi prefissi.
+    /// Esempio: ["/orders", "/customers"]
+    /// </summary>
+    public List<string> PathPrefixes { get; } = [];
+
+    /// <summary>
+    /// Include solo operazioni con uno di questi metodi HTTP.
+    /// Esempio: [HttpMethod.Get, HttpMethod.Post]
+    /// </summary>
+    public List<HttpMethod> Methods { get; } = [];
+}
+```
+
+---
+
+### Modifiche al modello di configurazione interno
+
+#### `EndpointToolBuilder<TClient>` — stato interno aggiuntivo
+
+```csharp
+internal sealed class EndpointToolBuilder<TClient> where TClient : class
+{
+    // Stato v1.0 — invariato
+    internal List<EndpointToolConfiguration> ManualTools { get; } = [];
+
+    // Stato v1.1 — aggiunto
+    internal AnyOf<string, Uri, Stream>? SpecSource { get; private set; }
+    internal OpenApiFilterSettings? SpecFilter { get; private set; }
+
+    // I toolName dichiarati via WithAction: usati per sapere quali operazioni
+    // della spec NON devono essere auto-generate (WithAction ha precedenza)
+    internal HashSet<string> ManualToolNames { get; } = new(StringComparer.OrdinalIgnoreCase);
+}
+```
+
+#### `SceneConfiguration` — campo aggiuntivo
+
+```csharp
+internal sealed class SceneConfiguration
+{
+    // ... campi v1.0 invariati ...
+
+    /// <summary>
+    /// Configurazioni di endpoint con sorgente OpenAPI da caricare lazily.
+    /// Ogni elemento rappresenta un WithEndpoint<TClient>(specSource, ...).
+    /// </summary>
+    public List<OpenApiEndpointGroupConfiguration> OpenApiEndpointGroups { get; set; } = [];
+}
+
+/// <summary>
+/// Configurazione di un gruppo di endpoint generati da una specifica OpenAPI.
+/// </summary>
+internal sealed class OpenApiEndpointGroupConfiguration
+{
+    public required Type ClientType { get; init; }
+    public required AnyOf<string, Uri, Stream> SpecSource { get; init; }
+    public OpenApiFilterSettings? Filter { get; init; }
+
+    /// <summary>
+    /// Tool dichiarati manualmente con WithAction nello stesso WithEndpoint.
+    /// Questi hanno precedenza sulle operazioni della spec con lo stesso toolName.
+    /// </summary>
+    public List<EndpointToolConfiguration> ManualOverrides { get; init; } = [];
+}
+```
+
+---
+
+### Nuovo componente: `OpenApiSpecLoader`
+
+```csharp
+// File: Services/Tools/OpenApiSpecLoader.cs
+
+/// <summary>
+/// Carica e cachea una specifica OpenAPI da URL, file path o stream.
+/// Thread-safe. Il parsing avviene una sola volta per sorgente.
+/// </summary>
+internal static class OpenApiSpecLoader
+{
+    // Cache keyed sul toString() della sorgente (URL o file path assoluto)
+    private static readonly ConcurrentDictionary<string, Task<OpenApiDocument>> _cache = new();
+
+    /// <summary>
+    /// Carica la specifica OpenAPI dalla sorgente indicata.
+    /// - Stringa che inizia con "http://" o "https://": fetch HTTP
+    /// - Stringa altrimenti: file path locale
+    /// - Uri: fetch HTTP
+    /// - Stream: lettura diretta (non cachata, stream consumato una sola volta)
+    /// </summary>
+    public static Task<OpenApiDocument> LoadAsync(
+        AnyOf<string, Uri, Stream> source,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Logica di caricamento:**
+
+1. `Stream` → lettura diretta con `OpenApiStreamReader`, nessuna cache (lo stream non è riproducibile)
+2. `Uri` o stringa `http/https` → download via `HttpClient` (client senza base address, solo per il fetch della spec), poi parse con `OpenApiStreamReader`; risultato cachato per URL
+3. Stringa altrimenti → `File.OpenRead(path)`, parse con `OpenApiStreamReader`; risultato cachato per path assoluto
+
+---
+
+### Modifiche a `Scene.cs` — inizializzazione lazy async
+
+In v1.0 i tool vengono costruiti nel costruttore di `Scene` (sincrono). In v1.1, la presenza di `OpenApiEndpointGroups` introduce tool che richiedono I/O asincrono.
+
+**Approccio:** `Tools` e `AiTools` diventano lazy, popolati da un metodo `EnsureInitializedAsync()` protetto da un `SemaphoreSlim(1,1)`. Tutte le chiamate a `scene.Tools` e `scene.AiTools` che avvengono dopo la costruzione (es. in `SceneExecutor`) passano per questo gate.
+
+```csharp
+internal sealed class Scene : IScene
+{
+    private readonly SemaphoreSlim _initLock = new(1, 1);
+    private bool _initialized = false;
+
+    // In v1.0 questi venivano popolati nel costruttore;
+    // in v1.1 vengono popolati da EnsureInitializedAsync().
+    public List<ISceneTool> Tools { get; private set; } = [];
+    public List<AITool> AiTools { get; private set; } = [];
+
+    /// <summary>
+    /// Garantisce che i tool derivati da spec OpenAPI siano stati caricati.
+    /// Chiamato da IScene prima di ogni utilizzo di Tools/AiTools.
+    /// Idempotente e thread-safe.
+    /// </summary>
+    public async Task EnsureInitializedAsync(CancellationToken cancellationToken = default)
+    {
+        if (_initialized) return;
+
+        await _initLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_initialized) return;
+
+            // Carica i tool da ogni gruppo OpenAPI
+            foreach (var group in _config.OpenApiEndpointGroups)
+            {
+                var specTools = await BuildToolsFromSpecAsync(group, cancellationToken);
+                Tools.AddRange(specTools);
+            }
+
+            AiTools = [.. Tools.Select(x => x.ToolDescription)];
+            _initialized = true;
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    private async Task<List<EndpointHttpTool>> BuildToolsFromSpecAsync(
+        OpenApiEndpointGroupConfiguration group,
+        CancellationToken cancellationToken)
+    {
+        var document = await OpenApiSpecLoader.LoadAsync(group.SpecSource, cancellationToken);
+        var tools = new List<EndpointHttpTool>();
+
+        var manualNames = group.ManualOverrides
+            .Select(t => t.ToolName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (path, pathItem) in document.Paths)
+        {
+            foreach (var (operationType, operation) in pathItem.Operations)
+            {
+                // Applicare filtri
+                if (!PassesFilter(operation, path, operationType, group.Filter))
+                    continue;
+
+                // Determinare il nome del tool
+                var toolName = ToolNameNormalizer.Normalize(
+                    !string.IsNullOrEmpty(operation.OperationId)
+                        ? operation.OperationId
+                        : $"{operationType}_{path.Replace("/", "_").Trim('_')}");
+
+                // WithAction manuale ha precedenza
+                if (manualNames.Contains(toolName))
+                    continue;
+
+                // Costruire EndpointToolConfiguration da spec
+                var config = BuildConfigFromOperation(
+                    group.ClientType, toolName, path, operationType, operation);
+
+                tools.Add(new EndpointHttpTool(config, _jsonService));
+            }
+        }
+
+        return tools;
+    }
+}
+```
+
+**Impatto su `IScene`:** aggiunta del metodo `Task EnsureInitializedAsync(CancellationToken)` all'interfaccia. Il chiamante (es. `SceneExecutor`) chiama `await scene.EnsureInitializedAsync()` prima di accedere a `scene.Tools`.
+
+---
+
+### Costruzione dello schema AI da operazione OpenAPI
+
+Per ogni operazione la spec fornisce:
+- **`parameters`**: array di `ParameterObject` con `name`, `in` (path/query/header/cookie), `description`, `required`, `schema`
+- **`requestBody`**: `RequestBodyObject` con `content["application/json"].schema`
+
+Lo schema AI unificato viene costruito così:
+
+```
+properties = {}
+required   = []
+
+per ogni parameter con in = "path" o "query":
+    properties[param.name] = {
+        "type":        OpenApiTypeToJsonSchemaType(param.schema),
+        "description": param.description ?? "Parameter: {param.name}"
+    }
+    se param.required: required.append(param.name)
+
+se requestBody presente e content["application/json"] esiste:
+    FlattenSchemaIntoProperties(requestBody.schema, properties, required)
+
+schema_finale = {
+    "type":       "object",
+    "properties": properties,
+    "required":   required   // omesso se vuoto
+}
+```
+
+`FlattenSchemaIntoProperties` risolve `$ref` (già risolti da `Microsoft.OpenApi`), gestisce `allOf` (merge delle proprietà), e copia le proprietà del body direttamente al top-level dello schema (lo stesso schema che `EndpointHttpTool` usa per separare route/query/body a runtime è gestito da `EndpointToolConfiguration`).
+
+---
+
+### Separazione route/query/body a runtime con spec
+
+Quando i tool vengono generati dalla spec, `EndpointToolConfiguration` include informazioni aggiuntive per sapere, per ogni parametro dell'AI, dove va nella request HTTP:
+
+```csharp
+internal sealed class EndpointToolConfiguration
+{
+    // ... campi v1.0 invariati ...
+
+    /// <summary>
+    /// v1.1: nomi dei parametri che provengono dal path (per sostituire nella route template).
+    /// Quando null, viene usato il parsing automatico da {} nella route template (comportamento v1.0).
+    /// </summary>
+    public HashSet<string>? RouteParameterNames { get; init; }
+
+    /// <summary>
+    /// v1.1: nomi dei parametri che vanno nella query string.
+    /// Quando null, vengono usati i QueryParameters dichiarati con WithParameter() (comportamento v1.0).
+    /// </summary>
+    public HashSet<string>? QueryParameterNames { get; init; }
+
+    /// <summary>
+    /// v1.1: nomi delle proprietà che fanno parte del request body.
+    /// Quando non null, ExtractBodyFromArguments usa questi nomi per costruire il body JSON
+    /// invece di serializzare RequestBodyType via reflection.
+    /// </summary>
+    public HashSet<string>? BodyPropertyNames { get; init; }
+}
+```
+
+---
+
+### File coinvolti v1.1 — Riepilogo incrementale
+
+I file v1.0 rimangono invariati salvo le modifiche indicate.
+
+| File | Azione | Contenuto |
+|------|--------|-----------|
+| `Builder/OpenApiFilterSettings.cs` | **Nuovo** | `OpenApiFilterSettings` con Tags, OperationIds, PathPrefixes, Methods |
+| `Services/Tools/OpenApiSpecLoader.cs` | **Nuovo** | Loader statico con cache `ConcurrentDictionary`, supporto URL/file/stream |
+| `Rystem.PlayFramework.csproj` | **Modifica** | Aggiunta `<PackageReference Include="Microsoft.OpenApi.Readers" Version="2.x" />` |
+| `Builder/EndpointToolBuilder.cs` | **Modifica** | Aggiunta `FilterSpec()`, stato `SpecSource`/`SpecFilter`/`ManualToolNames` |
+| `Builder/SceneBuilder.cs` | **Modifica** | Nuovo overload `WithEndpoint<TClient>(specSource, configure?)` + `OpenApiEndpointGroups` in `SceneConfiguration` |
+| `Services/Scenes/Scene.cs` | **Modifica** | Lazy init con `EnsureInitializedAsync()`, `BuildToolsFromSpecAsync()`, `BuildConfigFromOperation()` |
+| `Abstractions/IScene.cs` | **Modifica** | Aggiunta `Task EnsureInitializedAsync(CancellationToken)` |
+
+---
+
+### Esempi d'uso v1.1
+
+```csharp
+// Caso 1: spec completa come unica riga — tutti gli endpoint diventano tool
+scene.WithEndpoint<IOrderServiceClient>("http://localhost:5001/openapi/v1.json");
+
+// Caso 2: spec con filtro per tag
+scene.WithEndpoint<IOrderServiceClient>(
+    "http://localhost:5001/openapi/v1.json",
+    e => e.FilterSpec(f => f.Tags.Add("Orders")));
+
+// Caso 3: spec con filtro multiplo (solo GET e POST su /orders/*)
+scene.WithEndpoint<IOrderServiceClient>(
+    "./specs/orders-v2.json",
+    e => e.FilterSpec(f =>
+    {
+        f.PathPrefixes.Add("/orders");
+        f.Methods.Add(HttpMethod.Get);
+        f.Methods.Add(HttpMethod.Post);
+    }));
+
+// Caso 4: spec + override di una singola operazione
+// "CreateOrder" (operationId dalla spec) viene sostituito con la versione manuale
+scene.WithEndpoint<IOrderServiceClient>(
+    "http://localhost:5001/openapi/v1.json",
+    e => e
+        .FilterSpec(f => f.Tags.Add("Orders"))
+        .WithAction<CreateOrderRequest, OrderDto>(
+            "CreateOrder",           // toolName == operationId → sovrascrive la spec
+            HttpMethod.Post,
+            "/orders",
+            "Descrizione arricchita per l'AI, più dettagliata di quella nella spec"));
+
+// Caso 5: spec da stream (es. embedded resource)
+var stream = Assembly.GetExecutingAssembly()
+    .GetManifestResourceStream("MyApp.specs.orders.json")!;
+scene.WithEndpoint<IOrderServiceClient>(stream);
+
+// Caso 6: mix v1.0 e v1.1 nella stessa scena (due client diversi)
+scene.WithEndpoint<IOrderServiceClient>(
+    "http://localhost:5001/openapi/v1.json");  // v1.1: auto da spec
+
+scene.WithEndpoint<IInventoryServiceClient>(endpoint =>  // v1.0: manuale
+{
+    endpoint.WithAction<StockDto>("GetStock", HttpMethod.Get, "/stock/{sku}", "...");
+});
+```
+
+---
+
+### Decisioni di design v1.1
+
+| Decisione | Scelta | Motivazione |
+|-----------|--------|-------------|
+| Obiettivo | Spec come shortcut + override manuale possibile | Massima flessibilità senza duplicazione |
+| Dove si configura la spec | Overload su `WithEndpoint<TClient>` | Ogni scena può puntare a API diverse |
+| Formato sorgente | `AnyOf<string, Uri, Stream>` | Copre tutti i casi: URL remoto, file locale, stream embedded |
+| Quando viene caricata | Lazy al primo utilizzo della scena | Compatibile con URL self-hosted (app serve la propria spec) |
+| Parser OpenAPI | `Microsoft.OpenApi.Readers` | Parser ufficiale Microsoft, gestisce `$ref`, `allOf`, `oneOf` |
+| Filtro operazioni | `FilterSpec(Action<OpenApiFilterSettings>)` opzionale | Di default tutto incluso; filtri per Tags/OperationIds/PathPrefixes/Methods |
+| Naming tool | `operationId` se presente, altrimenti `{Method}_{path}` normalizzato | Standard OpenAPI, leggibile per l'AI |
+| Schema AI | Path params + query params + requestBody unificati | Schema completo per l'AI; separazione route/query/body gestita da `EndpointToolConfiguration` |
+| Precedenza WithAction vs spec | `WithAction` ha precedenza (match su `toolName == operationId`) | L'utente sovrascrive solo ciò che vuole |
+| servers[] della spec | Ignorati | Base URL sempre da `IHttpClientFactory` |
+| Lazy init in Scene.cs | `EnsureInitializedAsync()` con `SemaphoreSlim` | Thread-safe, compatibile con uso concorrente della stessa scena |
+| Cache spec | `ConcurrentDictionary` in `OpenApiSpecLoader` | Una sola fetch/parse per sorgente per lifetime dell'applicazione |

--- a/src/AI/Rystem.PlayFramework/Docs/SPEC-WithEndpoint.md
+++ b/src/AI/Rystem.PlayFramework/Docs/SPEC-WithEndpoint.md
@@ -41,44 +41,66 @@ Questa separazione garantisce che:
 #### 1. Registrazione HttpClient — `PlayFrameworkBuilder`
 
 ```csharp
-// File: Builder/PlayFrameworkBuilder_HttpClient.cs (partial class)
+// File: Builder/PlayFrameworkBuilder_HttpClient.cs (static extension class)
 
-public sealed partial class PlayFrameworkBuilder
+public static class PlayFrameworkBuilder_HttpClient
 {
     /// <summary>
-    /// Registra un HttpClient tipizzato tramite IHttpClientFactory.
+    /// Overload semplice: registra un HttpClient tipizzato configurando
+    /// direttamente l'istanza HttpClient (base address, timeout, header, ecc.).
     /// TClient è un tipo marker (interface vuota) usato come chiave per il named client.
-    /// Il configure espone IHttpClientBuilder standard .NET per configurare
-    /// base address, DelegatingHandler, Polly, timeout, ecc.
     /// </summary>
-    public PlayFrameworkBuilder WithHttpClient<TClient>(Action<IHttpClientBuilder> configure)
+    public static PlayFrameworkBuilder WithHttpClient<TClient>(
+        this PlayFrameworkBuilder builder,
+        Action<HttpClient> configureClient)
+        where TClient : class;
+
+    /// <summary>
+    /// Overload completo: configura sia l'istanza HttpClient sia l'IHttpClientBuilder
+    /// (DelegatingHandler, policy di resiliency, ecc.).
+    /// </summary>
+    public static PlayFrameworkBuilder WithHttpClient<TClient>(
+        this PlayFrameworkBuilder builder,
+        Action<HttpClient> configureClient,
+        Action<IHttpClientBuilder> configureBuilder)
         where TClient : class;
 }
 ```
 
-**Esempio d'uso:**
+**Esempio d'uso — overload semplice:**
 
 ```csharp
-builder.WithHttpClient<IOrderServiceClient>(httpBuilder =>
+builder.WithHttpClient<IOrderServiceClient>(client =>
 {
-    httpBuilder.ConfigureHttpClient(client =>
-    {
-        client.BaseAddress = new Uri("http://localhost:5001/api");
-        client.Timeout = TimeSpan.FromSeconds(30);
-    });
-
-    // DelegatingHandler per autenticazione Bearer
-    httpBuilder.AddHttpMessageHandler<BearerTokenHandler>();
-
-    // Resiliency con Polly (Microsoft.Extensions.Http.Resilience)
-    httpBuilder.AddStandardResilienceHandler();
+    client.BaseAddress = new Uri("http://localhost:5001/api");
+    client.Timeout = TimeSpan.FromSeconds(30);
 });
 ```
 
+**Esempio d'uso — overload completo (con handler e resiliency):**
+
+```csharp
+builder.WithHttpClient<IOrderServiceClient>(
+    client =>
+    {
+        client.BaseAddress = new Uri("http://localhost:5001/api");
+        client.Timeout = TimeSpan.FromSeconds(30);
+    },
+    httpBuilder =>
+    {
+        // DelegatingHandler per autenticazione Bearer
+        httpBuilder.AddHttpMessageHandler<BearerTokenHandler>();
+
+        // Resiliency con Polly (Microsoft.Extensions.Http.Resilience)
+        httpBuilder.AddStandardResilienceHandler();
+    });
+```
+
 **Dettagli implementativi:**
-- Internamente chiama `_services.AddHttpClient(typeof(TClient).Name)` e passa l'`IHttpClientBuilder` al delegate
+- Internamente chiama `services.AddHttpClient(typeof(TClient).Name, configureClient)` e, nell'overload completo, invoca `configureBuilder` sull'`IHttpClientBuilder` restituito
 - `TClient` è un **tipo marker** (tipicamente un'interface vuota): serve solo come chiave per risolvere il client corretto a runtime via `IHttpClientFactory.CreateClient(typeof(TClient).Name)`
-- L'utente ha accesso a **tutte** le estensioni standard di `IHttpClientBuilder`: `AddHttpMessageHandler`, `ConfigurePrimaryHttpMessageHandler`, `SetHandlerLifetime`, `AddStandardResilienceHandler`, ecc.
+- L'overload semplice è sufficiente per i casi base (base address, timeout, header)
+- L'overload completo dà accesso a **tutte** le estensioni standard di `IHttpClientBuilder`: `AddHttpMessageHandler`, `ConfigurePrimaryHttpMessageHandler`, `SetHandlerLifetime`, `AddStandardResilienceHandler`, ecc.
 
 ---
 
@@ -299,7 +321,10 @@ Lo schema JSON esposto al modello AI viene costruito nel costruttore di `Endpoin
 
 1. **Parametri route**: estratti dalla route template via regex `\{(\w+)\}` → diventano proprietà `string` nello schema
 2. **Query parameters**: dichiarati via `.WithParameter()` → proprietà nello schema con tipo specificato
-3. **Body (TRequest)**: se presente, le proprietà di `TRequest` vengono aggiunte allo schema tramite `AIJsonUtilities.CreateParametersJsonSchema(typeof(TRequest))`
+3. **Body (TRequest)**: se presente, le proprietà pubbliche di `TRequest` vengono aggiunte allo schema tramite **reflection CLR diretta** (`GetProperties(BindingFlags.Public | BindingFlags.Instance)`). Per ciascuna proprietà:
+   - Il nome JSON rispetta `[JsonPropertyName]` e cade in `camelCase` via `JsonNamingPolicy.CamelCase` se l'attributo è assente
+   - Il tipo JSON viene mappato con `MapTypeToJsonSchemaType()` (bool → `boolean`, int/long/… → `integer`, float/double/decimal → `number`, array/IEnumerable → `array`, classe non-string → `object`, tutto il resto → `string`)
+   - I value type non-nullable diventano `required`; reference type e nullable restano opzionali
 
 Lo schema risultante viene passato a `AIFunctionFactory.CreateDeclaration(name, description, schema)` per generare l'`AITool`.
 
@@ -371,23 +396,31 @@ public async Task<object?> ExecuteAsync(
     // 7. Leggere il body della response
     var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
-    // 8. Tentare la deserializzazione di TResponse
-    object? deserializedBody;
-    try
+    // 8. Parsing del body della response come JsonElement.
+    //    Il body NON viene deserializzato nel tipo TResponse: viene invece parsato come
+    //    JsonElement, che è nativamente serializzabile e preserva la struttura JSON
+    //    esattamente come il modello AI ha bisogno di vederla.
+    //    Questo evita problemi con tipi union (OneOf, AnyOf, ecc.) che richiederebbero
+    //    converter custom nel downstream serializer.
+    object? parsedBody = null;
+    if (!string.IsNullOrWhiteSpace(responseBody))
     {
-        deserializedBody = _jsonService.Deserialize(responseBody, _config.ResponseType);
-    }
-    catch
-    {
-        // Fallback: restituire il body come stringa
-        deserializedBody = responseBody;
+        try
+        {
+            parsedBody = JsonDocument.Parse(responseBody).RootElement.Clone();
+        }
+        catch
+        {
+            // Fallback: restituire il body come stringa
+            parsedBody = responseBody;
+        }
     }
 
     // 9. Restituire risultato con status code + body
     return new EndpointHttpResponse
     {
         StatusCode = (int)response.StatusCode,
-        Body = deserializedBody
+        Body = parsedBody
     };
 }
 ```
@@ -412,17 +445,51 @@ private string BuildUrl(Dictionary<string, JsonElement>? argsDict)
     }
 
     // Aggiunta query parameters
-    var queryParams = _config.QueryParameters
+    var queryParts = _config.QueryParameters
         .Where(qp => argsDict.ContainsKey(qp.Name))
-        .Select(qp => $"{qp.Name}={Uri.EscapeDataString(argsDict[qp.Name].GetString() ?? argsDict[qp.Name].GetRawText())}");
+        .Select(qp =>
+        {
+            var raw = argsDict[qp.Name].GetString() ?? argsDict[qp.Name].GetRawText();
+            return $"{qp.Name}={Uri.EscapeDataString(raw)}";
+        });
 
-    var queryString = string.Join("&", queryParams);
+    var queryString = string.Join("&", queryParts);
     if (!string.IsNullOrEmpty(queryString))
         url += $"?{queryString}";
 
     return url;
 }
 ```
+
+#### Estrazione body dagli argomenti AI
+
+Il metodo `ExtractBodyFromArguments` ricostruisce l'oggetto body filtrando dagli argomenti AI solo le proprietà che appartengono al body, escludendo route params e query params:
+
+```csharp
+private object? ExtractBodyFromArguments(Dictionary<string, JsonElement> argsDict)
+{
+    if (_config.RequestBodyType == null)
+        return null;
+
+    // Nomi da escludere: parametri route + parametri query
+    var skipNames = new HashSet<string>(_routeParameters, StringComparer.OrdinalIgnoreCase);
+    foreach (var qp in _config.QueryParameters)
+        skipNames.Add(qp.Name);
+
+    // Costruisce un JsonObject con sole le proprietà del body
+    var bodyNode = new JsonObject();
+    foreach (var kv in argsDict)
+    {
+        if (!skipNames.Contains(kv.Key))
+            bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
+    }
+
+    var bodyJson = bodyNode.ToJsonString();
+    return _jsonService.Deserialize(bodyJson, _config.RequestBodyType);
+}
+```
+
+Questo garantisce che per un endpoint `PUT /orders/{orderId}` con body `UpdateOrderRequest`, il valore `orderId` rimanga solo nell'URL e non venga serializzato nel body JSON.
 
 #### Tipo di risposta restituito all'AI
 
@@ -475,9 +542,8 @@ public enum PlayFrameworkToolSourceType
     Service,
     Client,
     Mcp,
-    Rag,
-    WebSearch,
-    Endpoint  // ← NUOVO VALORE
+    Endpoint,  // ← NUOVO VALORE
+    Other
 }
 ```
 
@@ -487,12 +553,74 @@ public enum PlayFrameworkToolSourceType
 
 | File | Azione | Contenuto |
 |------|--------|-----------|
-| `Builder/PlayFrameworkBuilder_HttpClient.cs` | **Nuovo** | Partial class con `WithHttpClient<TClient>()` |
+| `Builder/PlayFrameworkBuilder_HttpClient.cs` | **Nuovo** | Static class con due overload `WithHttpClient<TClient>()` |
 | `Builder/EndpointToolBuilder.cs` | **Nuovo** | `EndpointToolBuilder<TClient>`, `EndpointActionBuilder`, `EndpointToolConfiguration`, `EndpointParameterDefinition` |
 | `Services/Tools/EndpointHttpTool.cs` | **Nuovo** | Implementazione `ISceneTool` + `ISceneToolMetadata` per chiamate HTTP |
 | `Builder/SceneBuilder.cs` | **Modifica** | Aggiunta metodo `WithEndpoint<TClient>()` + campo `EndpointTools` in `SceneConfiguration` |
 | `Services/Scenes/Scene.cs` | **Modifica** | Istanziazione `EndpointHttpTool` dalla configurazione |
-| Enum `PlayFrameworkToolSourceType` | **Modifica** | Aggiunta valore `Endpoint` |
+| `Domain/Models/ForcedToolRequest.cs` | **Modifica** | Enum `PlayFrameworkToolSourceType` aggiornato + nuove proprietà opzionali su `ForcedToolRequest` |
+| `Api/Models/PlayFrameworkDiscoveryResponse.cs` | **Modifica** | Aggiunta proprietà `Endpoints` alla response di discovery |
+
+---
+
+### Modifiche a `ForcedToolRequest` e `PlayFrameworkToolSourceType`
+
+#### `ForcedToolRequest` — nuove proprietà opzionali
+
+La classe `ForcedToolRequest` (usata per forzare/vincolare tool specifici in una scena) riceve tre nuove proprietà opzionali che permettono di disambiguare tool omonimi:
+
+```csharp
+public sealed class ForcedToolRequest
+{
+    public required string SceneName { get; set; }
+    public required string ToolName { get; set; }
+
+    // ← NUOVO: disambiguazione per sorgente
+    public PlayFrameworkToolSourceType? SourceType { get; set; }
+    public string? SourceName { get; set; }
+    public string? MemberName { get; set; }
+}
+```
+
+- `SourceType`: tipo di sorgente (es. `Endpoint`) per distinguere tool con lo stesso nome provenenti da sorgenti diverse
+- `SourceName`: nome della sorgente (es. `IOrderServiceClient`) 
+- `MemberName`: nome del membro o route template (es. `/orders/{orderId}`)
+
+#### `PlayFrameworkToolSourceType` — valore `Endpoint`
+
+Il valore `Endpoint` è stato aggiunto all'enum esistente per identificare i tool basati su endpoint HTTP:
+
+```csharp
+public enum PlayFrameworkToolSourceType
+{
+    Service,   // Tool backed by a DI service method
+    Client,    // Tool executed on the client
+    Mcp,       // Tool exposed by an MCP server
+    Endpoint,  // ← NUOVO: Tool backed by an HTTP endpoint via typed HttpClient
+    Other      // Any other tool category
+}
+```
+
+---
+
+### Modifiche a `PlayFrameworkDiscoveryResponse`
+
+La response di discovery esposta dall'API HTTP riceve una nuova proprietà per raggruppare i tool di tipo endpoint:
+
+```csharp
+public sealed class PlayFrameworkDiscoveryResponse
+{
+    // ... proprietà esistenti ...
+
+    /// <summary>
+    /// HTTP endpoint tools backed by typed HttpClients.
+    /// Popolata con i tool di tipo PlayFrameworkToolSourceType.Endpoint.
+    /// </summary>
+    public List<PlayFrameworkToolSourceInfo> Endpoints { get; set; } = [];  // ← NUOVO
+}
+```
+
+Questa proprietà viene popolata da `WebApplicationExtensions` insieme alle proprietà `Services`, `Clients` e `McpServers` già esistenti.
 
 ---
 
@@ -519,16 +647,17 @@ public class BearerTokenHandler : DelegatingHandler
 services.AddPlayFramework(builder =>
 {
     // Registrazione client HTTP con auth + resiliency
-    builder.WithHttpClient<IOrderServiceClient>(http =>
-    {
-        http.ConfigureHttpClient(c =>
+    builder.WithHttpClient<IOrderServiceClient>(
+        client =>
         {
-            c.BaseAddress = new Uri("http://order-service:5001/api");
-            c.DefaultRequestHeaders.Add("X-Api-Version", "2");
+            client.BaseAddress = new Uri("http://order-service:5001/api");
+            client.DefaultRequestHeaders.Add("X-Api-Version", "2");
+        },
+        httpBuilder =>
+        {
+            httpBuilder.AddHttpMessageHandler<BearerTokenHandler>();
+            httpBuilder.AddStandardResilienceHandler();
         });
-        http.AddHttpMessageHandler<BearerTokenHandler>();
-        http.AddStandardResilienceHandler();
-    });
 
     // Configurazione scena
     builder.AddScene("OrderManagement", "Gestione ordini", scene =>

--- a/src/AI/Rystem.PlayFramework/Domain/Models/ForcedToolRequest.cs
+++ b/src/AI/Rystem.PlayFramework/Domain/Models/ForcedToolRequest.cs
@@ -54,6 +54,11 @@ public enum PlayFrameworkToolSourceType
     Mcp,
 
     /// <summary>
+    /// Tool backed by an HTTP endpoint via typed HttpClient.
+    /// </summary>
+    Endpoint,
+
+    /// <summary>
     /// Any other tool category.
     /// </summary>
     Other

--- a/src/AI/Rystem.PlayFramework/README.md
+++ b/src/AI/Rystem.PlayFramework/README.md
@@ -261,6 +261,7 @@ Scenes are the main unit of orchestration.
 `SceneBuilder` exposes the main extension points:
 
 - `WithService<TService>(...)`
+- `WithEndpoint<TClient>(...)`
 - `WithActors(...)`
 - `WithMcpServer(...)`
 - `OnClient(...)`
@@ -616,6 +617,7 @@ It returns:
 - `services` grouped by DI source
 - `clients` grouped by client-side source
 - `mcpServers` grouped by MCP source
+- `endpoints` grouped by HTTP client marker type
 - `others` for tools that do not belong to the standard buckets
 
 Use this endpoint from your frontend when you want to build a scene/tool picker and then feed the selected values back into `SceneRequestSettings.ForcedTools`.
@@ -1031,6 +1033,136 @@ builder.Services.AddPlayFramework("default", framework =>
         });
 });
 ```
+
+## Example: HTTP endpoint tools (WithEndpoint)
+
+`WithEndpoint<TClient>` turns any HTTP endpoint into an AI tool. Register the named HTTP client on the PlayFramework builder with `WithHttpClient<TClient>`, then register individual endpoints on the scene builder with `WithEndpoint<TClient>`. `TClient` is a marker type — the named `IHttpClientFactory` key is `typeof(TClient).Name`.
+
+### Register the HTTP client
+
+**Simple form** (configure the `HttpClient` only):
+
+```csharp
+builder.Services.AddPlayFramework("default", framework =>
+{
+    framework
+        .WithChatClient("default")
+        .WithHttpClient<IOrderServiceClient>(c =>
+        {
+            c.BaseAddress = new Uri("http://order-service:5001/api");
+            c.Timeout = TimeSpan.FromSeconds(30);
+        })
+        .AddScene("Orders", "Order management", scene =>
+        {
+            scene.WithEndpoint<IOrderServiceClient>(ep => ep
+                .WithAction<Order>(
+                    "GetOrder",
+                    HttpMethod.Get,
+                    "/orders/{orderId}",
+                    "Retrieve an order by its ID")
+                .WithAction<CreateOrderRequest, Order>(
+                    "CreateOrder",
+                    HttpMethod.Post,
+                    "/orders",
+                    "Create a new order"));
+        });
+});
+```
+
+**Full form** (also configure the `IHttpClientBuilder` for message handlers, Polly resilience, etc.):
+
+```csharp
+.WithHttpClient<IOrderServiceClient>(
+    c =>
+    {
+        c.BaseAddress = new Uri("http://order-service:5001/api");
+        c.Timeout = TimeSpan.FromSeconds(30);
+    },
+    b => b
+        .AddHttpMessageHandler<BearerTokenHandler>()
+        .AddStandardResilienceHandler())
+```
+
+### WithAction overloads
+
+| Overload | When to use |
+|---|---|
+| `WithAction<TResponse>(name, method, route, description)` | GET, DELETE, HEAD — no request body |
+| `WithAction<TRequest, TResponse>(name, method, route, description)` | POST, PUT, PATCH — typed request body |
+
+Route template placeholders (`{orderId}`) are extracted automatically as required AI parameters. Optional query-string parameters are added fluently with `.WithParameter(...)`:
+
+```csharp
+.WithAction<PagedResult<Order>>(
+    "ListOrders",
+    HttpMethod.Get,
+    "/orders",
+    "List all orders")
+.WithParameter("status", "Filter by status: pending, shipped, delivered")
+.WithParameter("pageSize", "Results per page", type: typeof(int))
+```
+
+### Force endpoint tools
+
+Endpoint tools appear in `ForcedTools` with `SourceType = Endpoint`:
+
+```csharp
+var settings = new SceneRequestSettings
+{
+    ExecutionMode = SceneExecutionMode.Scene,
+    SceneName = "Orders",
+    ForcedTools =
+    [
+        new ForcedToolRequest
+        {
+            SceneName = "Orders",
+            ToolName = "GetOrder",
+            SourceType = PlayFrameworkToolSourceType.Endpoint,
+            SourceName = "IOrderServiceClient",
+            MemberName = "GetOrder"
+        }
+    ]
+};
+```
+
+### Discovery response
+
+Endpoint tools appear in the `endpoints` array:
+
+```json
+{
+  "factoryName": "default",
+  "scenes": [...],
+  "services": [],
+  "clients": [],
+  "mcpServers": [],
+  "endpoints": [
+    {
+      "name": "IOrderServiceClient",
+      "sourceType": "Endpoint",
+      "isAvailable": true,
+      "tools": [
+        {
+          "sceneName": "Orders",
+          "toolName": "GetOrder",
+          "description": "Retrieve an order by its ID",
+          "sourceType": "Endpoint",
+          "sourceName": "IOrderServiceClient",
+          "memberName": "GetOrder"
+        }
+      ]
+    }
+  ],
+  "others": []
+}
+```
+
+Important behavior:
+
+- `TClient` is a **marker type**, not an actual client implementation. Any interface or class works.
+- Route template placeholders are parsed at registration time; the LLM must supply a value for each at call time.
+- The HTTP response is forwarded to the LLM as a raw `JsonElement`, which keeps it compatible with union types in downstream serializers.
+- Request body properties (from `TRequest`) and route/query parameters are kept separate; only body-eligible properties are serialized as the JSON body.
 
 ## Example: MCP server integration
 

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -52,6 +52,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Rystem.PlayFramework.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
     <None Include="rystem.png" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/AI/Rystem.PlayFramework/Services/Scenes/Scene.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Scenes/Scene.cs
@@ -24,6 +24,11 @@ internal sealed class Scene : IScene
             .Select(st => new ServiceMethodTool(st, jsonService))
             .ToList();
 
+        // Create tools from HTTP endpoint configurations
+        var endpointTools = _config.EndpointTools
+            .Select(et => new EndpointHttpTool(et, jsonService))
+            .ToList();
+
         // Create tools from client interactions (OnClient)
         var clientTools = _config.ClientInteractionDefinitions
             ?.Select(def => new ClientInteractionTool(def))
@@ -31,6 +36,7 @@ internal sealed class Scene : IScene
 
         // Combine all tools
         Tools = [.. serviceTools];
+        Tools.AddRange(endpointTools);
         Tools.AddRange(clientTools);
         AiTools = [.. Tools.Select(x => x.ToolDescription)];
         // Create actors

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -1,0 +1,309 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Rystem.PlayFramework.Helpers;
+
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// An <see cref="ISceneTool"/> that executes an HTTP endpoint as an AI tool.
+/// The tool schema is built at construction time from the route template,
+/// optional query parameters, and an optional typed request body.
+/// </summary>
+internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
+{
+    private readonly EndpointToolConfiguration _config;
+    private readonly IJsonService _jsonService;
+    private readonly List<string> _routeParameters;
+
+    // Regex to extract {param} placeholders from route templates
+    private static readonly Regex RouteParamRegex = new(@"\{(\w+)\}", RegexOptions.Compiled);
+
+    public EndpointHttpTool(EndpointToolConfiguration config, IJsonService? jsonService = null)
+    {
+        _config = config;
+        _jsonService = jsonService ?? new DefaultJsonService();
+
+        // Extract route parameter names once
+        _routeParameters = RouteParamRegex
+            .Matches(config.RouteTemplate)
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+
+        Name = config.ToolName;
+        Description = config.Description;
+        ToolDescription = BuildAiTool();
+    }
+
+    // ── ISceneTool ────────────────────────────────────────────────────────────
+
+    public string Name { get; }
+    public string Description { get; }
+    public AITool ToolDescription { get; }
+
+    // ── ISceneToolMetadata ────────────────────────────────────────────────────
+
+    public PlayFrameworkToolSourceType SourceType => PlayFrameworkToolSourceType.Endpoint;
+    public string? SourceName => _config.ClientType.Name;
+    public string? MemberName => _config.RouteTemplate;
+    public bool IsCommand => false;
+    public string? JsonSchema => null;
+
+    // ── Execution ─────────────────────────────────────────────────────────────
+
+    public async Task<object?> ExecuteAsync(
+        string arguments,
+        SceneContext context,
+        CancellationToken cancellationToken)
+    {
+        // 1. Resolve IHttpClientFactory from the DI container
+        var factory = context.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(_config.ClientType.Name);
+
+        // 2. Deserialise arguments JSON from the AI model
+        Dictionary<string, JsonElement>? argsDict = null;
+        if (!string.IsNullOrWhiteSpace(arguments) && arguments != "{}")
+        {
+            argsDict = _jsonService.Deserialize<Dictionary<string, JsonElement>>(arguments);
+        }
+
+        // 3. Build the request URL
+        var url = BuildUrl(argsDict);
+
+        // 4. Create the HttpRequestMessage
+        var request = new HttpRequestMessage(_config.HttpMethod, url);
+
+        // 5. Serialise and attach the request body when a body type is configured
+        if (_config.RequestBodyType != null && argsDict != null)
+        {
+            var body = ExtractBodyFromArguments(argsDict);
+            request.Content = new StringContent(
+                _jsonService.Serialize(body, _config.RequestBodyType),
+                Encoding.UTF8,
+                "application/json");
+        }
+
+        // 6. Send the request
+        var response = await client.SendAsync(request, cancellationToken);
+
+        // 7. Read the response body
+        var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        // 8. Try to deserialise into TResponse; fall back to raw string on failure
+        object? deserialisedBody;
+        try
+        {
+            deserialisedBody = _jsonService.Deserialize(responseBody, _config.ResponseType);
+        }
+        catch
+        {
+            deserialisedBody = responseBody;
+        }
+
+        // 9. Return status + body so the AI can react to 4xx/5xx errors
+        return new EndpointHttpResponse
+        {
+            StatusCode = (int)response.StatusCode,
+            Body = deserialisedBody
+        };
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private string BuildUrl(Dictionary<string, JsonElement>? argsDict)
+    {
+        var url = _config.RouteTemplate;
+
+        if (argsDict == null)
+            return url;
+
+        // Replace route placeholders: /orders/{orderId} → /orders/abc-123
+        foreach (var routeParam in _routeParameters)
+        {
+            if (argsDict.TryGetValue(routeParam, out var value))
+            {
+                url = url.Replace(
+                    $"{{{routeParam}}}",
+                    value.GetString() ?? value.GetRawText());
+            }
+        }
+
+        // Append query-string parameters
+        var queryParts = _config.QueryParameters
+            .Where(qp => argsDict.ContainsKey(qp.Name))
+            .Select(qp =>
+            {
+                var raw = argsDict[qp.Name].GetString() ?? argsDict[qp.Name].GetRawText();
+                return $"{qp.Name}={Uri.EscapeDataString(raw)}";
+            });
+
+        var queryString = string.Join("&", queryParts);
+        if (!string.IsNullOrEmpty(queryString))
+            url += $"?{queryString}";
+
+        return url;
+    }
+
+    /// <summary>
+    /// Reconstructs the request body object from the flat argument dictionary.
+    /// Only the properties of <see cref="EndpointToolConfiguration.RequestBodyType"/> are included.
+    /// </summary>
+    private object? ExtractBodyFromArguments(Dictionary<string, JsonElement> argsDict)
+    {
+        if (_config.RequestBodyType == null)
+            return null;
+
+        // Build a JsonObject with only the body properties and then deserialise it
+        var bodyNode = new JsonObject();
+
+        // Collect names to skip (route + query params)
+        var skipNames = new HashSet<string>(_routeParameters, StringComparer.OrdinalIgnoreCase);
+        foreach (var qp in _config.QueryParameters)
+            skipNames.Add(qp.Name);
+
+        foreach (var kv in argsDict)
+        {
+            if (!skipNames.Contains(kv.Key))
+                bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
+        }
+
+        var bodyJson = bodyNode.ToJsonString();
+        return _jsonService.Deserialize(bodyJson, _config.RequestBodyType);
+    }
+
+    // ── AI Tool construction ──────────────────────────────────────────────────
+
+    private AITool BuildAiTool()
+    {
+        var schemaElement = BuildParametersSchema();
+        return AIFunctionFactory.CreateDeclaration(Name, Description, schemaElement);
+    }
+
+    /// <summary>
+    /// Builds a JSON Schema <see cref="JsonElement"/> that describes the tool parameters:
+    /// route params + declared query params + (optional) request body properties.
+    /// </summary>
+    private JsonElement BuildParametersSchema()
+    {
+        var properties = new JsonObject();
+        var required = new JsonArray();
+
+        // ── Route parameters ─────────────────────────────────────────────────
+        foreach (var rp in _routeParameters)
+        {
+            properties[rp] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = $"Route parameter: {rp}"
+            };
+            required.Add(JsonValue.Create(rp)!);
+        }
+
+        // ── Query-string parameters ───────────────────────────────────────────
+        foreach (var qp in _config.QueryParameters)
+        {
+            properties[qp.Name] = new JsonObject
+            {
+                ["type"] = MapTypeToJsonSchemaType(qp.Type),
+                ["description"] = qp.Description
+            };
+            // Query params are optional by default (not added to required)
+        }
+
+        // ── Request body properties ───────────────────────────────────────────
+        if (_config.RequestBodyType != null)
+        {
+            foreach (var prop in _config.RequestBodyType
+                         .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!prop.CanRead)
+                    continue;
+
+                var jsonName = GetJsonPropertyName(prop);
+                properties[jsonName] = new JsonObject
+                {
+                    ["type"] = MapTypeToJsonSchemaType(prop.PropertyType)
+                };
+
+                // Non-nullable value types are required
+                if (prop.PropertyType.IsValueType
+                    && Nullable.GetUnderlyingType(prop.PropertyType) == null)
+                {
+                    required.Add(JsonValue.Create(jsonName)!);
+                }
+            }
+        }
+
+        var schema = new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = properties
+        };
+
+        if (required.Count > 0)
+            schema["required"] = required;
+
+        return JsonSerializer.Deserialize<JsonElement>(schema.ToJsonString());
+    }
+
+    /// <summary>Maps a CLR type to its JSON Schema "type" string.</summary>
+    private static string MapTypeToJsonSchemaType(Type type)
+    {
+        // Unwrap nullable
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlying == typeof(bool)) return "boolean";
+
+        if (underlying == typeof(byte)
+            || underlying == typeof(sbyte)
+            || underlying == typeof(short)
+            || underlying == typeof(ushort)
+            || underlying == typeof(int)
+            || underlying == typeof(uint)
+            || underlying == typeof(long)
+            || underlying == typeof(ulong))
+            return "integer";
+
+        if (underlying == typeof(float)
+            || underlying == typeof(double)
+            || underlying == typeof(decimal))
+            return "number";
+
+        if (underlying.IsArray
+            || (underlying.IsGenericType
+                && typeof(System.Collections.IEnumerable).IsAssignableFrom(underlying)))
+            return "array";
+
+        if (underlying.IsClass && underlying != typeof(string))
+            return "object";
+
+        // string, Guid, DateTime, DateTimeOffset, Uri, enums → "string"
+        return "string";
+    }
+
+    /// <summary>
+    /// Returns the JSON property name for a property, honouring <see cref="JsonPropertyNameAttribute"/>
+    /// and falling back to camelCase.
+    /// </summary>
+    private static string GetJsonPropertyName(PropertyInfo prop)
+    {
+        var attr = prop.GetCustomAttribute<JsonPropertyNameAttribute>();
+        return attr?.Name
+               ?? JsonNamingPolicy.CamelCase.ConvertName(prop.Name);
+    }
+}
+
+/// <summary>
+/// Response wrapper returned to the AI model after an HTTP endpoint call.
+/// Includes the HTTP status code so the model can react to errors (400, 422, 500, …).
+/// </summary>
+internal sealed class EndpointHttpResponse
+{
+    public int StatusCode { get; init; }
+    public object? Body { get; init; }
+}

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -76,7 +76,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         var url = BuildUrl(argsDict);
 
         // 4. Create the HttpRequestMessage
-        var request = new HttpRequestMessage(_config.HttpMethod, url);
+        using var request = new HttpRequestMessage(_config.HttpMethod, url);
 
         // 5. Serialise and attach the request body when a body type is configured
         if (_config.RequestBodyType != null && argsDict != null)
@@ -89,7 +89,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         }
 
         // 6. Send the request
-        var response = await client.SendAsync(request, cancellationToken);
+        using var response = await client.SendAsync(request, cancellationToken);
 
         // 7. Read the response body
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -22,7 +22,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
     private readonly List<string> _routeParameters;
 
     // Regex to extract {param} placeholders from route templates
-    private static readonly Regex RouteParamRegex = new(@"\{(\w+)\}", RegexOptions.Compiled);
+    private static readonly Regex RouteParamRegex = new(@"\{(\w+)\}", RegexOptions.Compiled, matchTimeout: TimeSpan.FromSeconds(1));
 
     public EndpointHttpTool(EndpointToolConfiguration config, IJsonService? jsonService = null)
     {

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -94,22 +94,32 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         // 7. Read the response body
         var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        // 8. Try to deserialise into TResponse; fall back to raw string on failure
-        object? deserialisedBody;
-        try
+        // 8. Parse the response body as a JsonElement so that it can always be
+        //    re-serialised safely by ToolExecutionManager, regardless of the
+        //    configured ResponseType (e.g. OneOf<T0,T1>, AnyOf, custom union
+        //    types). Deserialising into the C# type and then storing it in an
+        //    object? field would force the downstream serialiser to handle the
+        //    custom type — which fails without the right converters in scope.
+        //    JsonElement is natively serialisable and preserves the JSON shape
+        //    exactly as the AI needs to see it.
+        object? parsedBody = null;
+        if (!string.IsNullOrWhiteSpace(responseBody))
         {
-            deserialisedBody = _jsonService.Deserialize(responseBody, _config.ResponseType);
-        }
-        catch
-        {
-            deserialisedBody = responseBody;
+            try
+            {
+                parsedBody = JsonDocument.Parse(responseBody).RootElement.Clone();
+            }
+            catch
+            {
+                parsedBody = responseBody;
+            }
         }
 
         // 9. Return status + body so the AI can react to 4xx/5xx errors
         return new EndpointHttpResponse
         {
             StatusCode = (int)response.StatusCode,
-            Body = deserialisedBody
+            Body = parsedBody
         };
     }
 

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -176,10 +176,9 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         foreach (var qp in _config.QueryParameters)
             skipNames.Add(qp.Name);
 
-        foreach (var kv in argsDict)
+        foreach (var kv in argsDict.Where(kv => !skipNames.Contains(kv.Key)))
         {
-            if (!skipNames.Contains(kv.Key))
-                bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
+            bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
         }
 
         var bodyJson = bodyNode.ToJsonString();
@@ -255,8 +254,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
             ["properties"] = properties
         };
 
-        if (required.Count > 0)
-            schema["required"] = required;
+        schema["required"] = required;
 
         return JsonSerializer.Deserialize<JsonElement>(schema.ToJsonString());
     }

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Rystem.PlayFramework.Helpers;
 
 namespace Rystem.PlayFramework;
 

--- a/src/AI/Test/Rystem.PlayFramework.Test/Rystem.PlayFramework.Test.csproj
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Rystem.PlayFramework.Test.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Rystem.PlayFramework\Rystem.PlayFramework.csproj" />
+    <ProjectReference Include="..\..\..\Repository\RepositoryFramework.Infrastructure.InMemory\RepositoryFramework.Infrastructure.InMemory.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
@@ -10,7 +10,6 @@ namespace Rystem.PlayFramework.Test.Tests;
 // ── Marker types used as IHttpClientFactory keys ─────────────────────────────
 
 internal interface IOrderServiceClient { }
-internal interface IProductServiceClient { }
 
 // ── Shared HTTP helper types ──────────────────────────────────────────────────
 
@@ -120,74 +119,12 @@ public sealed class EndpointHttpToolTests
         var prop = tool.GetType().GetProperty("JsonSchema",
             BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
         Assert.NotNull(prop);
-        var value = prop!.GetValue(tool);
+        var value = prop.GetValue(tool);
         Assert.NotNull(value);
-        return (JsonElement)value!;
+        return (JsonElement)value;
     }
 
     // ── Helper: build a minimal ServiceProvider with one HTTP-endpoint scene ──
-
-    private static (ServiceProvider Provider, CapturingHttpHandler Handler)
-        BuildProvider(
-            string sceneName,
-            string toolName,
-            HttpMethod method,
-            string routeTemplate,
-            Type? requestBodyType,
-            Type responseType,
-            Action<EndpointActionBuilder>? configureQuery = null,
-            HttpStatusCode httpStatus = HttpStatusCode.OK,
-            string httpResponseBody = "\"ok\"")
-    {
-        var handler = new CapturingHttpHandler(
-            new HttpResponseMessage(httpStatus)
-            {
-                Content = new StringContent(httpResponseBody, Encoding.UTF8, "application/json")
-            });
-
-        var services = new ServiceCollection();
-        services.AddLogging();
-
-        // Register a no-op IChatClient (replaced per-test when needed)
-        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(toolName, []));
-
-        services.AddPlayFramework(builder =>
-        {
-            builder.WithHttpClient<IOrderServiceClient>(
-                c => c.BaseAddress = new Uri("http://order-api/"),
-                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
-
-            builder.AddScene(sceneName, $"{sceneName} scene", scene =>
-            {
-                scene.WithEndpoint<IOrderServiceClient>(ep =>
-                {
-                    EndpointActionBuilder actionBuilder;
-                    if (requestBodyType == null)
-                    {
-                        actionBuilder = ep.GetType()
-                            .GetMethod(nameof(EndpointToolBuilder<IOrderServiceClient>.WithAction),
-                                1, [typeof(string), typeof(HttpMethod), typeof(string), typeof(string)])!
-                            .MakeGenericMethod(responseType)
-                            .Invoke(ep, [toolName, method, routeTemplate, "Test tool"])
-                            as EndpointActionBuilder ?? throw new InvalidOperationException();
-                    }
-                    else
-                    {
-                        actionBuilder = ep.GetType()
-                            .GetMethod(nameof(EndpointToolBuilder<IOrderServiceClient>.WithAction),
-                                2, [typeof(string), typeof(HttpMethod), typeof(string), typeof(string)])!
-                            .MakeGenericMethod(requestBodyType, responseType)
-                            .Invoke(ep, [toolName, method, routeTemplate, "Test tool"])
-                            as EndpointActionBuilder ?? throw new InvalidOperationException();
-                    }
-
-                    configureQuery?.Invoke(actionBuilder);
-                });
-            });
-        });
-
-        return (services.BuildServiceProvider(), handler);
-    }
 
     // ── Group 1: Registration ─────────────────────────────────────────────────
 
@@ -217,7 +154,7 @@ public sealed class EndpointHttpToolTests
         var ordersScene = factory.TryGetScene("Orders");
 
         Assert.NotNull(ordersScene);
-        Assert.Single(ordersScene!.Tools);
+        Assert.Single(ordersScene.Tools);
         Assert.IsType<EndpointHttpTool>(ordersScene.Tools[0]);
         Assert.Equal("GetOrder", ordersScene.Tools[0].Name);
     }
@@ -231,7 +168,7 @@ public sealed class EndpointHttpToolTests
             {
                 Content = new StringContent(
                     """{"orderId":"x","status":"Ok"}""",
-                    System.Text.Encoding.UTF8,
+                    Encoding.UTF8,
                     "application/json")
             });
 
@@ -491,7 +428,7 @@ public sealed class EndpointHttpToolTests
         var meta = tool as ISceneToolMetadata;
 
         Assert.NotNull(meta);
-        Assert.Equal(PlayFrameworkToolSourceType.Endpoint, meta!.SourceType);
+        Assert.Equal(PlayFrameworkToolSourceType.Endpoint, meta.SourceType);
         Assert.Equal(nameof(IOrderServiceClient), meta.SourceName);
         Assert.Equal("/orders/{orderId}", meta.MemberName);
         Assert.False(meta.IsCommand);

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
@@ -153,11 +153,9 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-            {
-                http.ConfigurePrimaryHttpMessageHandler(() => handler);
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
-            });
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://order-api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
 
             builder.AddScene(sceneName, $"{sceneName} scene", scene =>
             {
@@ -202,8 +200,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -226,6 +223,61 @@ public sealed class EndpointHttpToolTests
     }
 
     [Fact]
+    public async Task Registration_WithClientAndBuilderConfig_HandlerIsInvoked()
+    {
+        // Verifies the two-parameter overload: Action<HttpClient> + Action<IHttpClientBuilder>
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"orderId":"x","status":"Ok"}""",
+                    System.Text.Encoding.UTF8,
+                    "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(
+            "GetOrder",
+            new Dictionary<string, object?> { ["orderId"] = "x" }));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(
+                c =>
+                {
+                    c.BaseAddress = new Uri("http://order-api/");
+                    c.Timeout = TimeSpan.FromSeconds(10);
+                },
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("Get order x", settings: settings)) { }
+
+        // The custom handler (via IHttpClientBuilder) was invoked
+        Assert.NotNull(handler.CapturedRequest);
+        Assert.Contains("x", handler.CapturedRequest!.RequestUri!.ToString());
+    }
+
+    [Fact]
     public void Registration_MultipleActions_AllToolsRegistered()
     {
         var services = new ServiceCollection();
@@ -234,8 +286,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -264,8 +315,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -294,8 +344,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -332,8 +381,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -378,8 +426,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -428,8 +475,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -476,11 +522,9 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-            {
-                http.ConfigurePrimaryHttpMessageHandler(() => handler);
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
-            });
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://order-api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -534,11 +578,9 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-            {
-                http.ConfigurePrimaryHttpMessageHandler(() => handler);
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
-            });
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://order-api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -591,11 +633,9 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-            {
-                http.ConfigurePrimaryHttpMessageHandler(() => handler);
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
-            });
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://order-api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -650,11 +690,9 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-            {
-                http.ConfigurePrimaryHttpMessageHandler(() => handler);
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
-            });
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://order-api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {
@@ -696,8 +734,7 @@ public sealed class EndpointHttpToolTests
 
         services.AddPlayFramework(builder =>
         {
-            builder.WithHttpClient<IOrderServiceClient>(http =>
-                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
 
             builder.AddScene("Orders", "Orders scene", scene =>
             {

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
@@ -1,0 +1,721 @@
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Test.Tests;
+
+// ── Marker types used as IHttpClientFactory keys ─────────────────────────────
+
+internal interface IOrderServiceClient { }
+internal interface IProductServiceClient { }
+
+// ── Shared HTTP helper types ──────────────────────────────────────────────────
+
+/// <summary>
+/// Captures the last outgoing <see cref="HttpRequestMessage"/> and returns a
+/// pre-configured <see cref="HttpResponseMessage"/>.
+/// </summary>
+internal sealed class CapturingHttpHandler : HttpMessageHandler
+{
+    private readonly HttpResponseMessage _response;
+
+    public HttpRequestMessage? CapturedRequest { get; private set; }
+    public string? CapturedRequestBody { get; private set; }
+
+    public CapturingHttpHandler(HttpResponseMessage response) => _response = response;
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        CapturedRequest = request;
+        if (request.Content is not null)
+            CapturedRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+        return _response;
+    }
+}
+
+/// <summary>
+/// Mock <see cref="IChatClient"/> that on the first call emits a single tool
+/// call with the configured arguments, and on every subsequent call returns a
+/// plain text "Done" message.
+/// </summary>
+internal sealed class EndpointToolCallingChatClient : IChatClient
+{
+    private readonly string _toolName;
+    private readonly Dictionary<string, object?> _arguments;
+    private int _callCount;
+
+    public EndpointToolCallingChatClient(string toolName, Dictionary<string, object?> arguments)
+    {
+        _toolName = toolName;
+        _arguments = arguments;
+    }
+
+    public ChatClientMetadata Metadata => new("endpoint-mock", null, "mock-model");
+
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        _callCount++;
+        ChatMessage msg;
+
+        if (_callCount == 1)
+        {
+            msg = new ChatMessage(ChatRole.Assistant, "Calling tool");
+            msg.Contents.Add(new FunctionCallContent(
+                Guid.NewGuid().ToString(),
+                _toolName,
+                _arguments));
+        }
+        else
+        {
+            msg = new ChatMessage(ChatRole.Assistant, "Done");
+        }
+
+        return Task.FromResult(new ChatResponse([msg]) { ModelId = "mock-model" });
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+    public void Dispose() { }
+}
+
+// ── Request / Response body DTOs used in schema tests ────────────────────────
+
+internal sealed class CreateOrderRequest
+{
+    public string CustomerName { get; set; } = "";
+    public int Quantity { get; set; }           // non-nullable value type → required
+    public decimal? TotalPrice { get; set; }    // nullable → not required
+}
+
+internal sealed class OrderResponse
+{
+    public string OrderId { get; set; } = "";
+    public string Status { get; set; } = "";
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+public sealed class EndpointHttpToolTests
+{
+    /// <summary>
+    /// Gets the JSON schema from an AITool via reflection, because in
+    /// Microsoft.Extensions.AI.Abstractions ≥ 10.4 the JsonSchema property is
+    /// declared on the concrete DefaultAIFunctionDeclaration class, not on AITool.
+    /// </summary>
+    private static JsonElement GetAiToolJsonSchema(AITool tool)
+    {
+        var prop = tool.GetType().GetProperty("JsonSchema",
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+        Assert.NotNull(prop);
+        var value = prop!.GetValue(tool);
+        Assert.NotNull(value);
+        return (JsonElement)value!;
+    }
+
+    // ── Helper: build a minimal ServiceProvider with one HTTP-endpoint scene ──
+
+    private static (ServiceProvider Provider, CapturingHttpHandler Handler)
+        BuildProvider(
+            string sceneName,
+            string toolName,
+            HttpMethod method,
+            string routeTemplate,
+            Type? requestBodyType,
+            Type responseType,
+            Action<EndpointActionBuilder>? configureQuery = null,
+            HttpStatusCode httpStatus = HttpStatusCode.OK,
+            string httpResponseBody = "\"ok\"")
+    {
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(httpStatus)
+            {
+                Content = new StringContent(httpResponseBody, Encoding.UTF8, "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Register a no-op IChatClient (replaced per-test when needed)
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(toolName, []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+            {
+                http.ConfigurePrimaryHttpMessageHandler(() => handler);
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
+            });
+
+            builder.AddScene(sceneName, $"{sceneName} scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    EndpointActionBuilder actionBuilder;
+                    if (requestBodyType == null)
+                    {
+                        actionBuilder = ep.GetType()
+                            .GetMethod(nameof(EndpointToolBuilder<IOrderServiceClient>.WithAction),
+                                1, [typeof(string), typeof(HttpMethod), typeof(string), typeof(string)])!
+                            .MakeGenericMethod(responseType)
+                            .Invoke(ep, [toolName, method, routeTemplate, "Test tool"])
+                            as EndpointActionBuilder ?? throw new InvalidOperationException();
+                    }
+                    else
+                    {
+                        actionBuilder = ep.GetType()
+                            .GetMethod(nameof(EndpointToolBuilder<IOrderServiceClient>.WithAction),
+                                2, [typeof(string), typeof(HttpMethod), typeof(string), typeof(string)])!
+                            .MakeGenericMethod(requestBodyType, responseType)
+                            .Invoke(ep, [toolName, method, routeTemplate, "Test tool"])
+                            as EndpointActionBuilder ?? throw new InvalidOperationException();
+                    }
+
+                    configureQuery?.Invoke(actionBuilder);
+                });
+            });
+        });
+
+        return (services.BuildServiceProvider(), handler);
+    }
+
+    // ── Group 1: Registration ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Registration_SingleGetAction_ToolAppearsInSceneTools()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("GetOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>(
+                        "GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var factory = sp.GetRequiredService<ISceneFactory>();
+        var ordersScene = factory.TryGetScene("Orders");
+
+        Assert.NotNull(ordersScene);
+        Assert.Single(ordersScene!.Tools);
+        Assert.IsType<EndpointHttpTool>(ordersScene.Tools[0]);
+        Assert.Equal("GetOrder", ordersScene.Tools[0].Name);
+    }
+
+    [Fact]
+    public void Registration_MultipleActions_AllToolsRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("GetOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                    ep.WithAction<CreateOrderRequest, OrderResponse>("CreateOrder", HttpMethod.Post, "/orders", "Create order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var scene = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!;
+
+        Assert.Equal(2, scene.Tools.Count);
+        Assert.Contains(scene.Tools, t => t.Name == "GetOrder");
+        Assert.Contains(scene.Tools, t => t.Name == "CreateOrder");
+    }
+
+    [Fact]
+    public void Registration_ToolNameWithSpaces_IsNormalized()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("Get_Order", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("Get Order", HttpMethod.Get, "/orders/{orderId}", "desc");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var scene = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!;
+
+        // Spaces → underscores via ToolNameNormalizer
+        Assert.Equal("Get_Order", scene.Tools[0].Name);
+    }
+
+    // ── Group 2: Schema ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Schema_GetWithRouteParam_SchemaContainsRequiredRouteParam()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("GetOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>(
+                        "GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!.Tools[0];
+        var schema = GetAiToolJsonSchema(tool.ToolDescription);
+
+        using var doc = JsonDocument.Parse(schema.GetRawText());
+        var root = doc.RootElement;
+
+        // Has "orderId" in properties
+        Assert.True(root.GetProperty("properties").TryGetProperty("orderId", out var orderIdProp));
+        Assert.Equal("string", orderIdProp.GetProperty("type").GetString());
+
+        // "orderId" is required
+        var required = root.GetProperty("required").EnumerateArray().Select(e => e.GetString()).ToList();
+        Assert.Contains("orderId", required);
+    }
+
+    [Fact]
+    public void Schema_GetWithQueryParam_SchemaContainsOptionalQueryParam()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("SearchOrders", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("SearchOrders", HttpMethod.Get, "/orders", "Search orders")
+                      .WithParameter("status", "Filter by status")
+                      .WithParameter("limit", "Max results", typeof(int));
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!.Tools[0];
+        var schema = GetAiToolJsonSchema(tool.ToolDescription);
+        using var doc = JsonDocument.Parse(schema.GetRawText());
+        var root = doc.RootElement;
+        var props = root.GetProperty("properties");
+
+        // "status" → string (default type)
+        Assert.True(props.TryGetProperty("status", out var statusProp));
+        Assert.Equal("string", statusProp.GetProperty("type").GetString());
+
+        // "limit" → integer
+        Assert.True(props.TryGetProperty("limit", out var limitProp));
+        Assert.Equal("integer", limitProp.GetProperty("type").GetString());
+
+        // Query params are NOT in the required array
+        var required = root.TryGetProperty("required", out var req)
+            ? req.EnumerateArray().Select(e => e.GetString()).ToList()
+            : [];
+        Assert.DoesNotContain("status", required);
+        Assert.DoesNotContain("limit", required);
+    }
+
+    [Fact]
+    public void Schema_PostWithRequestBody_SchemaContainsBodyProperties()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("CreateOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<CreateOrderRequest, OrderResponse>(
+                        "CreateOrder", HttpMethod.Post, "/orders", "Create a new order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!.Tools[0];
+        var schema = GetAiToolJsonSchema(tool.ToolDescription);
+        using var doc = JsonDocument.Parse(schema.GetRawText());
+        var props = doc.RootElement.GetProperty("properties");
+
+        // customerName → string (camelCase)
+        Assert.True(props.TryGetProperty("customerName", out var nameProp));
+        Assert.Equal("string", nameProp.GetProperty("type").GetString());
+
+        // quantity → integer (non-nullable value type → required)
+        Assert.True(props.TryGetProperty("quantity", out var qtyProp));
+        Assert.Equal("integer", qtyProp.GetProperty("type").GetString());
+
+        // totalPrice → number (nullable decimal → optional)
+        Assert.True(props.TryGetProperty("totalPrice", out var priceProp));
+        Assert.Equal("number", priceProp.GetProperty("type").GetString());
+
+        // "quantity" is required, "totalPrice" is not
+        var required = doc.RootElement.GetProperty("required").EnumerateArray()
+            .Select(e => e.GetString()).ToList();
+        Assert.Contains("quantity", required);
+        Assert.DoesNotContain("totalPrice", required);
+        Assert.DoesNotContain("customerName", required);
+    }
+
+    // ── Group 3: Metadata ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Metadata_EndpointTool_HasCorrectSourceType()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("GetOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!.Tools[0];
+        var meta = tool as ISceneToolMetadata;
+
+        Assert.NotNull(meta);
+        Assert.Equal(PlayFrameworkToolSourceType.Endpoint, meta!.SourceType);
+        Assert.Equal(nameof(IOrderServiceClient), meta.SourceName);
+        Assert.Equal("/orders/{orderId}", meta.MemberName);
+        Assert.False(meta.IsCommand);
+    }
+
+    // ── Group 4: HTTP Execution via end-to-end pipeline ───────────────────────
+
+    [Fact]
+    public async Task Execution_GetWithRouteParam_SendsCorrectHttpRequest()
+    {
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"orderId":"order-123","status":"Shipped"}""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var chatClient = new EndpointToolCallingChatClient(
+            "GetOrder",
+            new Dictionary<string, object?> { ["orderId"] = "order-123" });
+
+        services.AddSingleton<IChatClient>(chatClient);
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+            {
+                http.ConfigurePrimaryHttpMessageHandler(() => handler);
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
+            });
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>(
+                        "GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get an order by ID");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        var responses = new List<AiSceneResponse>();
+        await foreach (var r in sceneManager.ExecuteAsync("Get order 123", settings: settings))
+            responses.Add(r);
+
+        // HTTP request was sent
+        Assert.NotNull(handler.CapturedRequest);
+        Assert.Equal(HttpMethod.Get, handler.CapturedRequest!.Method);
+        Assert.Contains("order-123", handler.CapturedRequest.RequestUri!.ToString());
+
+        // Scene execution completed
+        Assert.Contains(responses, r => r.Status == AiResponseStatus.FunctionCompleted
+                                        && r.FunctionName == "GetOrder");
+        Assert.Contains(responses, r => r.Status == AiResponseStatus.Completed);
+    }
+
+    [Fact]
+    public async Task Execution_GetWithQueryParam_AppendsQueryStringToUrl()
+    {
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(
+            "SearchOrders",
+            new Dictionary<string, object?> { ["status"] = "Shipped" }));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+            {
+                http.ConfigurePrimaryHttpMessageHandler(() => handler);
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
+            });
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("SearchOrders", HttpMethod.Get, "/orders", "Search")
+                      .WithParameter("status", "Filter by order status");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("Find shipped orders", settings: settings)) { }
+
+        Assert.NotNull(handler.CapturedRequest);
+        var url = handler.CapturedRequest!.RequestUri!.ToString();
+        Assert.Contains("status=Shipped", url);
+    }
+
+    [Fact]
+    public async Task Execution_PostWithBody_SerializesBodyCorrectly()
+    {
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent(
+                    """{"orderId":"new-order","status":"Pending"}""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(
+            "CreateOrder",
+            new Dictionary<string, object?>
+            {
+                ["customerName"] = "Alice",
+                ["quantity"] = 3
+            }));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+            {
+                http.ConfigurePrimaryHttpMessageHandler(() => handler);
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
+            });
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<CreateOrderRequest, OrderResponse>(
+                        "CreateOrder", HttpMethod.Post, "/orders", "Create order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("Create order for Alice", settings: settings)) { }
+
+        Assert.NotNull(handler.CapturedRequest);
+        Assert.Equal(HttpMethod.Post, handler.CapturedRequest!.Method);
+        Assert.NotNull(handler.CapturedRequestBody);
+
+        // Request body should contain the body fields
+        Assert.Contains("customerName", handler.CapturedRequestBody!,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Alice", handler.CapturedRequestBody!);
+    }
+
+    [Fact]
+    public async Task Execution_NonSuccessHttpResponse_ToolStillCompletes()
+    {
+        // EndpointHttpTool does NOT throw on non-2xx; it returns the status code to the AI.
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent(
+                    """{"error":"order not found"}""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(
+            "GetOrder",
+            new Dictionary<string, object?> { ["orderId"] = "missing-id" }));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+            {
+                http.ConfigurePrimaryHttpMessageHandler(() => handler);
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://order-api/"));
+            });
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>(
+                        "GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        var responses = new List<AiSceneResponse>();
+        await foreach (var r in sceneManager.ExecuteAsync("Get missing order", settings: settings))
+            responses.Add(r);
+
+        // Tool execution should complete (not error) — the 404 is passed to the AI as tool result
+        Assert.Contains(responses, r => r.Status == AiResponseStatus.FunctionCompleted
+                                        && r.FunctionName == "GetOrder");
+        Assert.DoesNotContain(responses, r => r.Status == AiResponseStatus.Error);
+    }
+
+    // ── Group 5: AiTools list reflects registered endpoints ───────────────────
+
+    [Fact]
+    public void AiTools_RegisteredEndpoints_AppearInSceneAiTools()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("GetOrder", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(http =>
+                http.ConfigureHttpClient(c => c.BaseAddress = new Uri("http://api/")));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get order");
+                    ep.WithAction<CreateOrderRequest, OrderResponse>("CreateOrder", HttpMethod.Post, "/orders", "Create order");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var scene = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!;
+
+        // AiTools mirrors Tools
+        Assert.Equal(scene.Tools.Count, scene.AiTools.Count);
+        var toolNames = scene.AiTools.Select(t => t.Name).ToList();
+        Assert.Contains("GetOrder", toolNames);
+        Assert.Contains("CreateOrder", toolNames);
+    }
+}

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/MemoryTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/MemoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using RepositoryFramework.InMemory;
 using Rystem.PlayFramework.Test.Infrastructure;
 
 namespace Rystem.PlayFramework.Test.Tests;
@@ -27,6 +28,7 @@ public sealed class MemoryTests
             builder.AddScene("TestScene", "Test scene", _ => { });
 
             builder.WithMemory(memory => memory
+                .UseRepository((name, repo) => repo.WithInMemory(name: name))
                 .WithMaxSummaryLength(1000));
         });
 
@@ -80,6 +82,7 @@ public sealed class MemoryTests
             builder.AddScene("TestScene", "Test scene", _ => { });
 
             builder.WithMemory(memory => memory
+                .UseRepository((name, repo) => repo.WithInMemory(name: name))
                 .WithDefaultMemoryStorage("userId")
                 .WithMaxSummaryLength(1000));
         });
@@ -131,6 +134,7 @@ public sealed class MemoryTests
             builder.AddScene("TestScene", "Test scene", _ => { });
 
             builder.WithMemory(memory => memory
+                .UseRepository((name, repo) => repo.WithInMemory(name: name))
                 .WithDefaultMemoryStorage("userId", "tenantId")
                 .WithMaxSummaryLength(1000));
         });


### PR DESCRIPTION
# Description

This PR adds a new feature to the `Rystem.PlayFramework` library that allows AI scenes to call arbitrary HTTP endpoints as tools.

---

## What was added

### `WithEndpoint<TClient>(...)` on `SceneBuilder`

A new fluent API that lets you register typed `IHttpClientFactory` clients as AI tools inside a scene:

```csharp

builder.AddScene("Orders", "Orders scene", scene =>
{
    scene.WithEndpoint<IOrderServiceClient>(ep =>
    {
        ep.WithAction<OrderResponse>(
            "GetOrder", HttpMethod.Get, "/orders/{orderId}", "Get an order by ID");
        ep.WithAction<CreateOrderRequest, OrderResponse>(
            "CreateOrder", HttpMethod.Post, "/orders", "Create order");
    });
});

```

---

## Key components

| File | Purpose |
|---|---|
| `EndpointHttpTool.cs` | Core `ISceneTool` implementation that sends an HTTP request and returns status + body to the AI |
| `EndpointToolBuilder.cs` | Fluent builder for registering actions (`WithAction<TResponse>` / `WithAction<TRequest, TResponse>`) and optional query parameters |
| `PlayFrameworkBuilder_HttpClient.cs` | New `WithHttpClient<TClient>()` extension on the top-level builder to register typed HTTP clients |
| `SceneBuilder.cs` | Adds `WithEndpoint<TClient>()` to the scene configuration DSL |

---

## How the tool works

1. **Schema generation**  

   At construction time, `EndpointHttpTool` inspects the route template (e.g. `{orderId}`), declared query parameters, and the optional request body DTO to build a JSON Schema that the AI model uses to call the tool.

2. **Execution**  

   At call time it:

   - Resolves an `IHttpClientFactory` from the DI container
   - Substitutes route and query parameters from the AI's arguments
   - Serialises the request body (if any) as JSON
   - Sends the HTTP request
   - Returns `{ statusCode, body }` so the AI can react to errors (`4xx` / `5xx`) without throwing

3. **New source type**  

   `PlayFrameworkToolSourceType.Endpoint` was added to distinguish these tools from `Service` and `Mcp` tools.

---

## Schema rules

| Parameter kind | JSON Schema presence |
|---|---|
| Route param (`{id}`) | Always included |
| Query param | Always included |
| Body DTO — value type | Reflected via CLR |
| Body DTO — nullable | Reflected via CLR |

Property names on body DTOs honour `[JsonPropertyName]` and fall back to `camelCase`.

---

## Testing

xUnit tests (`EndpointHttpToolTests.cs`) covering five groups:

- **Registration**
  - Single/multiple tools
  - Tool name normalisation (`spaces → underscores`)

- **Schema**
  - Route params are required
  - Query params are optional
  - Body DTOs are reflected correctly with `camelCase` naming and correct nullability rules

- **Metadata**
  - `SourceType`, `SourceName`, `MemberName` are set correctly

- **Execution (end-to-end)**
  - `GET` with route parameters sends the correct URL
  - `GET` with query parameters appends the query string
  - `POST` with a body DTO serialises the body correctly
  - Non-2xx responses do not throw — the status code is forwarded to the AI as tool result

- **AiTools list**
  - Registered endpoint tools appear in `scene.AiTools`