### PR TITLE
feat: add business hooks for PlayFramework

### DIFF
--- a/src/AI/Rystem.PlayFramework/Api/PlayFrameworkApiSettings.cs
+++ b/src/AI/Rystem.PlayFramework/Api/PlayFrameworkApiSettings.cs
@@ -81,4 +81,12 @@ public sealed class PlayFrameworkApiSettings
     /// Default: 25MB (OpenAI Whisper limit).
     /// </summary>
     public long MaxAudioUploadSize { get; set; } = 26_214_400; // 25MB
+
+    /// <summary>
+    /// Server-side timeout in seconds for the entire business pipeline
+    /// (BeforeExecution hooks → scene streaming → AfterEachScene → OnTerminalScene hooks).
+    /// 0 or negative = no timeout (default).
+    /// When the timeout expires the endpoint returns <c>408 Request Timeout</c>.
+    /// </summary>
+    public int TimeoutInSeconds { get; set; } = 0;
 }

--- a/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
+++ b/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
@@ -19,6 +19,7 @@ namespace Rystem.PlayFramework.Api;
 /// </summary>
 public static class WebApplicationExtensions
 {
+    private const string UnknownValue = "unknown";
     /// <summary>
     /// Maps PlayFramework endpoints.
     /// - If factoryName is null: Creates generic endpoints accepting factoryName in route (/{factoryName}, /{factoryName}/streaming)
@@ -73,6 +74,7 @@ public static class WebApplicationExtensions
         group.MapPost(stepRoute, async (
             [FromBody] PlayFrameworkRequest request,
             [FromServices] IFactory<ISceneManager> sceneManagerFactory,
+            [FromServices] IFactory<IPlayFrameworkBusinessManager> businessManagerFactory,
             [FromServices] ILogger<ISceneManager> logger,
             HttpContext httpContext,
             CancellationToken cancellationToken) =>
@@ -80,7 +82,7 @@ public static class WebApplicationExtensions
             // Get factory from closure or route parameter
             var routeFactory = httpContext.GetRouteValue("factoryName")?.ToString();
             var targetFactory = factoryName ?? routeFactory ?? "default";
-            await ExecutePlayFrameworkAsync(targetFactory, request, sceneManagerFactory, logger, httpContext, settings, cancellationToken);
+            await ExecutePlayFrameworkAsync(targetFactory, request, sceneManagerFactory, businessManagerFactory, logger, httpContext, settings, cancellationToken);
         })
         .WithName(stepEndpointName)
         .WithSummary(stepSummary)
@@ -90,6 +92,7 @@ public static class WebApplicationExtensions
         group.MapPost(streamingRoute, async (
             [FromBody] PlayFrameworkRequest request,
             [FromServices] IFactory<ISceneManager> sceneManagerFactory,
+            [FromServices] IFactory<IPlayFrameworkBusinessManager> businessManagerFactory,
             [FromServices] ILogger<ISceneManager> logger,
             HttpContext httpContext,
             CancellationToken cancellationToken) =>
@@ -102,7 +105,7 @@ public static class WebApplicationExtensions
             request.Settings ??= new SceneRequestSettings();
             request.Settings.EnableStreaming = true;
 
-            await ExecutePlayFrameworkAsync(targetFactory, request, sceneManagerFactory, logger, httpContext, settings, cancellationToken);
+            await ExecutePlayFrameworkAsync(targetFactory, request, sceneManagerFactory, businessManagerFactory, logger, httpContext, settings, cancellationToken);
         })
         .WithName(streamingEndpointName)
         .WithSummary(streamingSummary)
@@ -274,12 +277,17 @@ public static class WebApplicationExtensions
 
     /// <summary>
     /// Core execution logic shared by all endpoints.
-    /// Handles SSE streaming, error handling, and response serialization.
+    /// Delegates to <see cref="IPlayFrameworkBusinessManager"/> which orchestrates
+    /// before-execution hooks, scene streaming, after-each-scene hooks, and on-terminal hooks.
+    /// SSE response headers are written lazily (only once the first real scene event arrives),
+    /// allowing a <see cref="PlayFrameworkDenyResult"/> to be returned as a plain HTTP error
+    /// before the stream is opened.
     /// </summary>
     private static async Task ExecutePlayFrameworkAsync(
         string factoryName,
         PlayFrameworkRequest request,
         IFactory<ISceneManager> sceneManagerFactory,
+        IFactory<IPlayFrameworkBusinessManager> businessManagerFactory,
         ILogger<ISceneManager> logger,
         HttpContext httpContext,
         PlayFrameworkApiSettings settings,
@@ -287,57 +295,134 @@ public static class WebApplicationExtensions
     {
         var lastKnownTotalCost = 0m;
         string? lastKnownConversationKey = null;
+
+        // Build optional server-side timeout
+        CancellationTokenSource? timeoutCts = null;
+        CancellationTokenSource? linkedCts = null;
+        CancellationToken pipelineCt = cancellationToken;
+
         try
         {
-            // Get SceneManager for factory
-            var sceneManager = sceneManagerFactory.Create(factoryName);
+            if (settings.TimeoutInSeconds > 0)
+            {
+                timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(settings.TimeoutInSeconds));
+                linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+                pipelineCt = linkedCts.Token;
+            }
 
             // Extract metadata from HTTP context
             var metadata = BuildMetadata(request.Metadata, httpContext, settings);
 
-            // Convert request to MultiModalInput and merge settings
-            var input = request.ToMultiModalInput();
-            var mergedSettings = request.GetMergedSettings();
+            // Build execution context
+            var mergedSettings = request.GetMergedSettings() ?? new SceneRequestSettings();
+            lastKnownConversationKey = mergedSettings.ConversationKey;
 
-            lastKnownConversationKey = mergedSettings?.ConversationKey;
-
-            // Set response headers for SSE
-            httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
-            httpContext.Response.Headers.Append("Cache-Control", "no-cache");
-            httpContext.Response.Headers.Append("Connection", "keep-alive");
-
-            // Execute PlayFramework with streaming
-            await foreach (var response in sceneManager.ExecuteAsync(input, metadata, mergedSettings, cancellationToken))
+            var context = new PlayFrameworkExecutionContext
             {
-                if (response.TotalCost > 0)
-                    lastKnownTotalCost = response.TotalCost;
-                if (response.ConversationKey != null)
-                    lastKnownConversationKey = response.ConversationKey;
+                Message = request.Message ?? string.Empty,
+                Input = request.ToMultiModalInput(),
+                ConversationKey = mergedSettings.ConversationKey,
+                Settings = mergedSettings,
+                Metadata = metadata,
+                User = httpContext.User
+            };
 
-                // Serialize response as SSE event with camelCase for properties and enums
-                var json = JsonSerializer.Serialize(response, JsonHelper.JsonSerializerOptions);
+            // Resolve the business manager for this factory
+            var manager = businessManagerFactory.Create(factoryName)
+                ?? throw new InvalidOperationException($"IPlayFrameworkBusinessManager not found for factory '{factoryName}'");
 
+            var sseHeadersWritten = false;
+
+            await foreach (var (scene, deny) in manager.ExecuteAsync(factoryName, context, pipelineCt))
+            {
+                // Deny: respond before opening SSE (headers not yet sent)
+                if (deny is not null)
+                {
+                    httpContext.Response.StatusCode = deny.StatusCode;
+                    var denyBody = JsonSerializer.Serialize(new
+                    {
+                        error = deny.ErrorDetail ?? "Request denied"
+                    }, JsonHelper.JsonSerializerOptions);
+                    httpContext.Response.ContentType = "application/json";
+                    await httpContext.Response.WriteAsync(denyBody, cancellationToken);
+                    return;
+                }
+
+                if (scene is null)
+                    continue;
+
+                // Lazy SSE headers — written once, on first scene item
+                if (!sseHeadersWritten)
+                {
+                    httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
+                    httpContext.Response.Headers.Append("Cache-Control", "no-cache");
+                    httpContext.Response.Headers.Append("Connection", "keep-alive");
+                    sseHeadersWritten = true;
+                }
+
+                if (scene.TotalCost > 0)
+                    lastKnownTotalCost = scene.TotalCost;
+                if (scene.ConversationKey != null)
+                    lastKnownConversationKey = scene.ConversationKey;
+
+                var json = JsonSerializer.Serialize(scene, JsonHelper.JsonSerializerOptions);
                 await httpContext.Response.WriteAsync($"data: {json}\n\n", cancellationToken);
                 await httpContext.Response.Body.FlushAsync(cancellationToken);
             }
+        }
+        catch (OperationCanceledException) when (timeoutCts?.IsCancellationRequested == true)
+        {
+            logger.LogWarning("PlayFramework execution timed out for factory '{FactoryName}'", factoryName);
 
-            // No need to send explicit completion marker - SceneManager always sends Completed as final event
+            if (!httpContext.Response.HasStarted)
+            {
+                httpContext.Response.StatusCode = 408;
+                await httpContext.Response.WriteAsJsonAsync(new
+                {
+                    error = "Request timeout",
+                    totalCost = lastKnownTotalCost,
+                    conversationKey = lastKnownConversationKey
+                }, cancellationToken: default);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Client disconnected — no response needed
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "PlayFramework execution failed for factory '{FactoryName}'", factoryName);
 
-            // Send error event with camelCase
-            var errorJson = JsonSerializer.Serialize(new
+            if (!httpContext.Response.HasStarted)
             {
-                status = "error",
-                errorMessage = ex.Message,
-                totalCost = lastKnownTotalCost,
-                conversationKey = lastKnownConversationKey
-            }, JsonHelper.JsonSerializerOptions);
+                // SSE not yet opened — respond with a structured JSON error
+                httpContext.Response.StatusCode = 500;
+                await httpContext.Response.WriteAsJsonAsync(new
+                {
+                    error = ex.Message,
+                    totalCost = lastKnownTotalCost,
+                    conversationKey = lastKnownConversationKey
+                }, cancellationToken: default);
+            }
+            else
+            {
+                // SSE already open — send error as SSE event
+                var errorJson = JsonSerializer.Serialize(new
+                {
+                    status = "error",
+                    errorMessage = ex.Message,
+                    totalCost = lastKnownTotalCost,
+                    conversationKey = lastKnownConversationKey
+                }, JsonHelper.JsonSerializerOptions);
 
-            await httpContext.Response.WriteAsync($"data: {errorJson}\n\n", cancellationToken);
-            await httpContext.Response.Body.FlushAsync(cancellationToken);
+                await httpContext.Response.WriteAsync($"data: {errorJson}\n\n", cancellationToken: default);
+                await httpContext.Response.Body.FlushAsync(cancellationToken: default);
+            }
+        }
+        finally
+        {
+            linkedCts?.Dispose();
+            timeoutCts?.Dispose();
         }
     }
 
@@ -366,7 +451,7 @@ public static class WebApplicationExtensions
             // Add IP address
             if (!metadata.ContainsKey("ipAddress"))
             {
-                metadata["ipAddress"] = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+                metadata["ipAddress"] = httpContext.Connection.RemoteIpAddress?.ToString() ?? UnknownValue;
             }
 
             // Add request ID (for tracing)
@@ -502,13 +587,13 @@ public static class WebApplicationExtensions
         switch (tool.SourceType)
         {
             case PlayFrameworkToolSourceType.Service:
-                AddToolIfMissing(GetOrCreateSource(services, tool.SourceName ?? "unknown", PlayFrameworkToolSourceType.Service).Tools, tool);
+                AddToolIfMissing(GetOrCreateSource(services, tool.SourceName ?? UnknownValue, PlayFrameworkToolSourceType.Service).Tools, tool);
                 break;
             case PlayFrameworkToolSourceType.Client:
                 AddToolIfMissing(GetOrCreateSource(clients, tool.SourceName ?? "client", PlayFrameworkToolSourceType.Client).Tools, tool);
                 break;
             case PlayFrameworkToolSourceType.Endpoint:
-                AddToolIfMissing(GetOrCreateSource(endpoints, tool.SourceName ?? "unknown", PlayFrameworkToolSourceType.Endpoint).Tools, tool);
+                AddToolIfMissing(GetOrCreateSource(endpoints, tool.SourceName ?? UnknownValue, PlayFrameworkToolSourceType.Endpoint).Tools, tool);
                 break;
             default:
                 AddToolIfMissing(response.Others, tool);
@@ -1028,7 +1113,7 @@ public static class WebApplicationExtensions
                         totalVoiceCost = voiceResponse.TotalVoiceCost
                     } as object,
 
-                    _ => new { type = "unknown" } as object
+                    _ => new { type = UnknownValue } as object
                 };
 
                 var json = JsonSerializer.Serialize(eventData, JsonHelper.JsonSerializerOptions);

--- a/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
+++ b/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
@@ -376,6 +376,7 @@ public static class WebApplicationExtensions
 
             if (!httpContext.Response.HasStarted)
             {
+                // SSE stream not yet opened — return plain HTTP 408
                 httpContext.Response.StatusCode = 408;
                 await httpContext.Response.WriteAsJsonAsync(new
                 {
@@ -383,6 +384,21 @@ public static class WebApplicationExtensions
                     totalCost = lastKnownTotalCost,
                     conversationKey = lastKnownConversationKey
                 }, cancellationToken: default);
+            }
+            else
+            {
+                // SSE stream already open — emit synthetic Timeout item so clients
+                // receive a well-typed terminal event instead of a silent stream close.
+                var timeoutResponse = new AiSceneResponse
+                {
+                    Status = AiResponseStatus.Timeout,
+                    ErrorMessage = "Request timed out",
+                    TotalCost = lastKnownTotalCost,
+                    ConversationKey = lastKnownConversationKey
+                };
+                var timeoutJson = JsonSerializer.Serialize(timeoutResponse, JsonHelper.JsonSerializerOptions);
+                await httpContext.Response.WriteAsync($"data: {timeoutJson}\n\n", cancellationToken: default);
+                await httpContext.Response.Body.FlushAsync(cancellationToken: default);
             }
         }
         catch (OperationCanceledException)

--- a/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Rystem.PlayFramework.Builder;
 using Rystem.PlayFramework.Helpers;
 using Rystem.PlayFramework.Telemetry;
 
@@ -25,6 +26,19 @@ public sealed class PlayFrameworkBuilder
     internal Type? CustomMemoryType { get; set; }
     internal Type? CustomMemoryStorageType { get; set; }
     internal bool HasRepository { get; set; }
+
+    /// <summary>
+    /// Fluent builder for registering business hooks (before-execution, after-each-scene, on-terminal-scene).
+    /// Lazily initialized on first access.
+    /// </summary>
+    public PlayFrameworkBusinessBuilder Business => _business ??= new PlayFrameworkBusinessBuilder(Services, Name);
+    private PlayFrameworkBusinessBuilder? _business;
+
+    /// <summary>
+    /// Called by <see cref="ServiceCollectionExtensions"/> after the user's configure lambda.
+    /// Always builds the hook registry (even when no hooks were registered).
+    /// </summary>
+    internal void BuildBusinessRegistry() => Business.BuildRegistry();
 
     /// <summary>
     /// Factory name of the <see cref="IVoiceAdapter"/> to use for the voice pipeline.

--- a/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBusinessBuilder.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBusinessBuilder.cs
@@ -65,10 +65,10 @@ public sealed class PlayFrameworkBusinessBuilder
     internal void BuildRegistry()
     {
         var registry = new PlayFrameworkHookRegistry();
-        foreach (var (_, impl, priority) in _registrations)
-        {
-            registry.Register(impl, priority);
-        }
+
+        // Pre-compute sorted positions once at startup.
+        // Equal-priority hooks preserve registration order (stable sort).
+        registry.Build(_registrations);
 
         // Register registry as singleton factory-keyed (CreateAll not needed — single instance per name)
         _services.AddFactory(registry, _name, ServiceLifetime.Singleton);

--- a/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBusinessBuilder.cs
+++ b/src/AI/Rystem.PlayFramework/Builder/PlayFrameworkBusinessBuilder.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Builder;
+
+/// <summary>
+/// Fluent builder for registering business hooks on a PlayFramework factory.
+/// Accessed via <see cref="PlayFrameworkBuilder.Business"/>.
+/// </summary>
+public sealed class PlayFrameworkBusinessBuilder
+{
+    private readonly IServiceCollection _services;
+    private readonly AnyOf<string?, Enum>? _name;
+
+    // Tracks (hookInterface, hookImplementation, priority) in registration order.
+    private readonly List<(Type HookInterface, Type HookImpl, int Priority)> _registrations = [];
+
+    internal PlayFrameworkBusinessBuilder(IServiceCollection services, AnyOf<string?, Enum>? name)
+    {
+        _services = services;
+        _name = name;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="IPlayFrameworkBeforeExecution"/> hook.
+    /// Hooks run in ascending <paramref name="priority"/> order.
+    /// </summary>
+    public PlayFrameworkBusinessBuilder AddBeforeExecution<T>(int priority = 0)
+        where T : class, IPlayFrameworkBeforeExecution
+    {
+        _services.AddFactory<IPlayFrameworkBeforeExecution, T>(_name, ServiceLifetime.Scoped);
+        _registrations.Add((typeof(IPlayFrameworkBeforeExecution), typeof(T), priority));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="IPlayFrameworkAfterEachScene"/> hook.
+    /// Hooks run in ascending <paramref name="priority"/> order.
+    /// </summary>
+    public PlayFrameworkBusinessBuilder AddAfterEachScene<T>(int priority = 0)
+        where T : class, IPlayFrameworkAfterEachScene
+    {
+        _services.AddFactory<IPlayFrameworkAfterEachScene, T>(_name, ServiceLifetime.Scoped);
+        _registrations.Add((typeof(IPlayFrameworkAfterEachScene), typeof(T), priority));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="IPlayFrameworkOnTerminalScene"/> hook.
+    /// Hooks run in ascending <paramref name="priority"/> order.
+    /// </summary>
+    public PlayFrameworkBusinessBuilder AddOnTerminalScene<T>(int priority = 0)
+        where T : class, IPlayFrameworkOnTerminalScene
+    {
+        _services.AddFactory<IPlayFrameworkOnTerminalScene, T>(_name, ServiceLifetime.Scoped);
+        _registrations.Add((typeof(IPlayFrameworkOnTerminalScene), typeof(T), priority));
+        return this;
+    }
+
+    /// <summary>
+    /// Builds and registers the <see cref="PlayFrameworkHookRegistry"/> singleton and the
+    /// <see cref="IPlayFrameworkBusinessManager"/> factory for this factory name.
+    /// Called automatically by <see cref="ServiceCollectionExtensions.AddPlayFramework(Microsoft.Extensions.DependencyInjection.IServiceCollection,AnyOf{string?,Enum}?,Action{PlayFrameworkBuilder})"/>
+    /// after the user's configure lambda has run.
+    /// </summary>
+    internal void BuildRegistry()
+    {
+        var registry = new PlayFrameworkHookRegistry();
+        foreach (var (_, impl, priority) in _registrations)
+        {
+            registry.Register(impl, priority);
+        }
+
+        // Register registry as singleton factory-keyed (CreateAll not needed — single instance per name)
+        _services.AddFactory(registry, _name, ServiceLifetime.Singleton);
+
+        // Register business manager factory-keyed (Scoped — one per request)
+        _services.AddFactory<IPlayFrameworkBusinessManager, PlayFrameworkBusinessManager>(_name, ServiceLifetime.Scoped);
+    }
+}

--- a/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkAfterEachScene.cs
+++ b/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkAfterEachScene.cs
@@ -1,0 +1,24 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Hook that runs for every <see cref="AiSceneResponse"/> produced by the stream,
+/// before the item is written to the SSE channel.
+/// </summary>
+public interface IPlayFrameworkAfterEachScene
+{
+    /// <summary>
+    /// Called for each scene response.
+    /// </summary>
+    /// <param name="scene">The scene response from the scene manager.</param>
+    /// <param name="context">Shared execution context for this request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="PlayFrameworkSceneResult.Forward(AiSceneResponse)"/> to forward (optionally modified),
+    /// <see cref="PlayFrameworkSceneResult.Suppress()"/> to discard the item,
+    /// or <see cref="PlayFrameworkSceneResult.ForwardAndInject(AiSceneResponse, AiSceneResponse[])"/> to forward and append extra items.
+    /// </returns>
+    Task<PlayFrameworkSceneResult> AfterSceneAsync(
+        AiSceneResponse scene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkBeforeExecution.cs
+++ b/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkBeforeExecution.cs
@@ -1,0 +1,22 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Hook that runs once before the scene stream starts.
+/// Can allow, deny, or short-circuit the execution pipeline.
+/// </summary>
+public interface IPlayFrameworkBeforeExecution
+{
+    /// <summary>
+    /// Called before PlayFramework starts streaming.
+    /// </summary>
+    /// <param name="context">Shared execution context for this request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="PlayFrameworkGuardResult.Allow()"/> to proceed,
+    /// <see cref="PlayFrameworkGuardResult.Deny(int, string?)"/> to block with an HTTP error,
+    /// or <see cref="PlayFrameworkGuardResult.ShortCircuit(AiSceneResponse)"/> to return a synthetic SSE response.
+    /// </returns>
+    Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkBusinessManager.cs
@@ -1,0 +1,28 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Orchestrates the full business pipeline for a PlayFramework request:
+/// before-execution guards → scene streaming → after-each-scene hooks → on-terminal hooks.
+/// </summary>
+public interface IPlayFrameworkBusinessManager
+{
+    /// <summary>
+    /// Executes the full pipeline and streams results.
+    /// </summary>
+    /// <param name="factoryName">The factory name used to resolve hooks and the scene manager.</param>
+    /// <param name="context">The execution context built from the incoming request.</param>
+    /// <param name="cancellationToken">
+    /// Cancellation token. The caller (endpoint handler) is responsible for linking a timeout
+    /// <see cref="System.Threading.CancellationTokenSource"/> before invoking this method.
+    /// </param>
+    /// <returns>
+    /// An async stream of tuples.
+    /// When <c>Deny</c> is non-null the stream yields exactly one item and terminates: the
+    /// endpoint handler must respond with the deny status code instead of opening SSE.
+    /// When <c>Scene</c> is non-null the item should be written as an SSE event.
+    /// </returns>
+    IAsyncEnumerable<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)> ExecuteAsync(
+        string factoryName,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkOnTerminalScene.cs
+++ b/src/AI/Rystem.PlayFramework/Business/IPlayFrameworkOnTerminalScene.cs
@@ -1,0 +1,26 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Hook that runs once when a terminal status is detected
+/// (<see cref="AiResponseStatus.Completed"/>, <see cref="AiResponseStatus.Error"/>,
+/// <see cref="AiResponseStatus.BudgetExceeded"/>, <see cref="AiResponseStatus.Unauthorized"/>).
+/// The terminal response is sent to the client first; extra items returned by this hook are
+/// appended to the SSE stream afterwards.
+/// </summary>
+public interface IPlayFrameworkOnTerminalScene
+{
+    /// <summary>
+    /// Called after the terminal scene has been sent to the client.
+    /// </summary>
+    /// <param name="terminalScene">The scene response that triggered the terminal state.</param>
+    /// <param name="context">Shared execution context for this request.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <c>null</c> or empty = no additional items.
+    /// Non-empty list = additional items to append to the SSE stream (in order, bypassing after-each-scene hooks).
+    /// </returns>
+    Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+        AiSceneResponse terminalScene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using Rystem.PlayFramework.Telemetry;
 
 namespace Rystem.PlayFramework;
 
@@ -46,6 +48,10 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
         PlayFrameworkExecutionContext context,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        using var businessActivity = PlayFrameworkActivitySource.Instance
+            .StartActivity(PlayFrameworkActivitySource.Activities.BusinessExecute, ActivityKind.Internal);
+        businessActivity?.SetTag(PlayFrameworkActivitySource.Tags.FactoryName, factoryName);
+
         var registry = _registryFactory.Create(factoryName)!;
 
         // ── 1. BeforeExecution hooks ──────────────────────────────────────────
@@ -55,20 +61,36 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
 
         foreach (var hook in beforeHooks)
         {
+            var hookTypeName = hook.GetType().Name;
+            using var hookActivity = PlayFrameworkActivitySource.Instance
+                .StartActivity(PlayFrameworkActivitySource.Activities.BusinessBeforeExecutionHook, ActivityKind.Internal);
+            hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
+
             var guard = await hook.BeforeExecutionAsync(context, cancellationToken);
 
             if (guard.Type == PlayFrameworkGuardResultType.Deny)
             {
+                hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "Deny");
+                hookActivity?.AddEvent(new ActivityEvent(PlayFrameworkActivitySource.Events.HookDenied));
+                hookActivity?.SetStatus(ActivityStatusCode.Ok);
+                businessActivity?.SetStatus(ActivityStatusCode.Ok);
                 yield return (null, guard.DenyResult);
                 yield break;
             }
 
             if (guard.Type == PlayFrameworkGuardResultType.ShortCircuit)
             {
+                hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "ShortCircuit");
+                hookActivity?.AddEvent(new ActivityEvent(PlayFrameworkActivitySource.Events.HookShortCircuited));
+                hookActivity?.SetStatus(ActivityStatusCode.Ok);
+                businessActivity?.SetStatus(ActivityStatusCode.Ok);
                 yield return (guard.ShortCircuitResponse, null);
                 yield break;
             }
+
             // Allow → continue to next hook
+            hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "Allow");
+            hookActivity?.SetStatus(ActivityStatusCode.Ok);
         }
 
         // ── 2. Execute scene manager ──────────────────────────────────────────
@@ -103,21 +125,33 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
 
                 foreach (var hook in afterHooks)
                 {
+                    var hookTypeName = hook.GetType().Name;
+                    using var hookActivity = PlayFrameworkActivitySource.Instance
+                        .StartActivity(PlayFrameworkActivitySource.Activities.BusinessAfterEachSceneHook, ActivityKind.Internal);
+                    hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
+
                     var result = await hook.AfterSceneAsync(current, context, cancellationToken);
 
                     switch (result.Type)
                     {
                         case PlayFrameworkSceneResultType.Suppress:
                             suppressed = true;
+                            hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "Suppress");
+                            hookActivity?.AddEvent(new ActivityEvent(PlayFrameworkActivitySource.Events.HookSuppressed));
+                            hookActivity?.SetStatus(ActivityStatusCode.Ok);
                             goto afterHooksDone; // break inner loop
 
                         case PlayFrameworkSceneResultType.ForwardAndInject:
                             current = result.Scene!;
                             extras = result.ExtraItems;
+                            hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "ForwardAndInject");
+                            hookActivity?.SetStatus(ActivityStatusCode.Ok);
                             goto afterHooksDone; // extras bypass further after-hooks
 
                         default: // Forward
                             current = result.Scene!;
+                            hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "Forward");
+                            hookActivity?.SetStatus(ActivityStatusCode.Ok);
                             break;
                     }
                 }
@@ -142,14 +176,24 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
             {
                 foreach (var hook in terminalHooks)
                 {
+                    var hookTypeName = hook.GetType().Name;
+                    using var hookActivity = PlayFrameworkActivitySource.Instance
+                        .StartActivity(PlayFrameworkActivitySource.Activities.BusinessOnTerminalSceneHook, ActivityKind.Internal);
+                    hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
+
                     var injected = await hook.OnTerminalAsync(response, context, cancellationToken);
                     if (injected is not null)
                     {
                         foreach (var item in injected)
                             yield return (item, null);
                     }
+
+                    hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookOutcome, "Completed");
+                    hookActivity?.SetStatus(ActivityStatusCode.Ok);
                 }
             }
         }
+
+        businessActivity?.SetStatus(ActivityStatusCode.Ok);
     }
 }

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
@@ -1,0 +1,153 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Default implementation of <see cref="IPlayFrameworkBusinessManager"/>.
+/// Resolves hooks via the Rystem factory pattern, sorts them by priority, and orchestrates
+/// the full before-execution → scene-stream → after-each-scene → on-terminal-scene pipeline.
+/// </summary>
+internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManager
+{
+    private readonly IFactory<IPlayFrameworkBeforeExecution> _beforeFactory;
+    private readonly IFactory<IPlayFrameworkAfterEachScene> _afterFactory;
+    private readonly IFactory<IPlayFrameworkOnTerminalScene> _terminalFactory;
+    private readonly IFactory<ISceneManager> _sceneManagerFactory;
+    private readonly IFactory<PlayFrameworkHookRegistry> _registryFactory;
+
+    private static readonly HashSet<AiResponseStatus> TerminalStatuses =
+    [
+        AiResponseStatus.Completed,
+        AiResponseStatus.Error,
+        AiResponseStatus.BudgetExceeded,
+        AiResponseStatus.Unauthorized
+    ];
+
+    public PlayFrameworkBusinessManager(
+        IFactory<IPlayFrameworkBeforeExecution> beforeFactory,
+        IFactory<IPlayFrameworkAfterEachScene> afterFactory,
+        IFactory<IPlayFrameworkOnTerminalScene> terminalFactory,
+        IFactory<ISceneManager> sceneManagerFactory,
+        IFactory<PlayFrameworkHookRegistry> registryFactory)
+    {
+        _beforeFactory = beforeFactory;
+        _afterFactory = afterFactory;
+        _terminalFactory = terminalFactory;
+        _sceneManagerFactory = sceneManagerFactory;
+        _registryFactory = registryFactory;
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)> ExecuteAsync(
+        string factoryName,
+        PlayFrameworkExecutionContext context,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var registry = _registryFactory.Create(factoryName)!;
+
+        // ── 1. BeforeExecution hooks ──────────────────────────────────────────
+        var beforeHooks = registry
+            .SortByPriority(_beforeFactory.CreateAll(factoryName))
+            .ToList();
+
+        foreach (var hook in beforeHooks)
+        {
+            var guard = await hook.BeforeExecutionAsync(context, cancellationToken);
+
+            if (guard.Type == PlayFrameworkGuardResultType.Deny)
+            {
+                yield return (null, guard.DenyResult);
+                yield break;
+            }
+
+            if (guard.Type == PlayFrameworkGuardResultType.ShortCircuit)
+            {
+                yield return (guard.ShortCircuitResponse, null);
+                yield break;
+            }
+            // Allow → continue to next hook
+        }
+
+        // ── 2. Execute scene manager ──────────────────────────────────────────
+        var sceneManager = _sceneManagerFactory.Create(factoryName)!;
+
+        var afterHooks = registry
+            .SortByPriority(_afterFactory.CreateAll(factoryName))
+            .ToList();
+
+        var terminalHooks = registry
+            .SortByPriority(_terminalFactory.CreateAll(factoryName))
+            .ToList();
+
+        var stream = context.Input is not null
+            ? sceneManager.ExecuteAsync(context.Input, context.Metadata, context.Settings, cancellationToken)
+            : sceneManager.ExecuteAsync(context.Message, context.Metadata, context.Settings, cancellationToken);
+
+        await foreach (var response in stream)
+        {
+            var isTerminal = TerminalStatuses.Contains(response.Status);
+
+            // ── 3. AfterEachScene hooks (skipped when none registered) ─────────
+            if (afterHooks.Count == 0)
+            {
+                yield return (response, null);
+            }
+            else
+            {
+                var current = response;
+                AiSceneResponse[]? extras = null;
+                var suppressed = false;
+
+                foreach (var hook in afterHooks)
+                {
+                    var result = await hook.AfterSceneAsync(current, context, cancellationToken);
+
+                    switch (result.Type)
+                    {
+                        case PlayFrameworkSceneResultType.Suppress:
+                            suppressed = true;
+                            goto afterHooksDone; // break inner loop
+
+                        case PlayFrameworkSceneResultType.ForwardAndInject:
+                            current = result.Scene!;
+                            extras = result.ExtraItems;
+                            goto afterHooksDone; // extras bypass further after-hooks
+
+                        default: // Forward
+                            current = result.Scene!;
+                            break;
+                    }
+                }
+
+                afterHooksDone:
+                if (!suppressed)
+                {
+                    yield return (current, null);
+
+                    // Extra items from ForwardAndInject bypass after-hooks
+                    if (extras is not null)
+                    {
+                        foreach (var extra in extras)
+                            yield return (extra, null);
+                    }
+                }
+            }
+
+            // ── 4. OnTerminalScene hooks ──────────────────────────────────────
+            // Fires even when the triggering item was suppressed (trigger is status, not send)
+            if (isTerminal && terminalHooks.Count > 0)
+            {
+                foreach (var hook in terminalHooks)
+                {
+                    var injected = await hook.OnTerminalAsync(response, context, cancellationToken);
+                    if (injected is not null)
+                    {
+                        foreach (var item in injected)
+                            yield return (item, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
@@ -21,7 +21,9 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
         AiResponseStatus.Completed,
         AiResponseStatus.Error,
         AiResponseStatus.BudgetExceeded,
-        AiResponseStatus.Unauthorized
+        AiResponseStatus.Unauthorized,
+        AiResponseStatus.Timeout,
+        AiResponseStatus.RateLimited
     ];
 
     public PlayFrameworkBusinessManager(

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
@@ -61,12 +61,23 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
 
         foreach (var hook in beforeHooks)
         {
-            var hookTypeName = hook.GetType().Name;
+            var hookType = hook.GetType();
+            var hookTypeName = hookType.Name;
             using var hookActivity = PlayFrameworkActivitySource.Instance
                 .StartActivity(PlayFrameworkActivitySource.Activities.BusinessBeforeExecutionHook, ActivityKind.Internal);
             hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
 
-            var guard = await hook.BeforeExecutionAsync(context, cancellationToken);
+            PlayFrameworkGuardResult guard;
+            try
+            {
+                guard = await hook.BeforeExecutionAsync(context, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                hookActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw new PlayFrameworkHookException(
+                    hookTypeName, "BeforeExecution", registry.GetPriority(hookType), ex);
+            }
 
             if (guard.Type == PlayFrameworkGuardResultType.Deny)
             {
@@ -125,12 +136,23 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
 
                 foreach (var hook in afterHooks)
                 {
-                    var hookTypeName = hook.GetType().Name;
+                    var hookType = hook.GetType();
+                    var hookTypeName = hookType.Name;
                     using var hookActivity = PlayFrameworkActivitySource.Instance
                         .StartActivity(PlayFrameworkActivitySource.Activities.BusinessAfterEachSceneHook, ActivityKind.Internal);
                     hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
 
-                    var result = await hook.AfterSceneAsync(current, context, cancellationToken);
+                    PlayFrameworkSceneResult result;
+                    try
+                    {
+                        result = await hook.AfterSceneAsync(current, context, cancellationToken);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        hookActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                        throw new PlayFrameworkHookException(
+                            hookTypeName, "AfterEachScene", registry.GetPriority(hookType), ex);
+                    }
 
                     switch (result.Type)
                     {
@@ -176,12 +198,23 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
             {
                 foreach (var hook in terminalHooks)
                 {
-                    var hookTypeName = hook.GetType().Name;
+                    var hookType = hook.GetType();
+                    var hookTypeName = hookType.Name;
                     using var hookActivity = PlayFrameworkActivitySource.Instance
                         .StartActivity(PlayFrameworkActivitySource.Activities.BusinessOnTerminalSceneHook, ActivityKind.Internal);
                     hookActivity?.SetTag(PlayFrameworkActivitySource.Tags.HookType, hookTypeName);
 
-                    var injected = await hook.OnTerminalAsync(response, context, cancellationToken);
+                    IEnumerable<AiSceneResponse>? injected;
+                    try
+                    {
+                        injected = await hook.OnTerminalAsync(response, context, cancellationToken);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        hookActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                        throw new PlayFrameworkHookException(
+                            hookTypeName, "OnTerminalScene", registry.GetPriority(hookType), ex);
+                    }
                     if (injected is not null)
                     {
                         foreach (var item in injected)

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkBusinessManager.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Rystem.PlayFramework.Telemetry;
 
 namespace Rystem.PlayFramework;
@@ -17,6 +18,10 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
     private readonly IFactory<IPlayFrameworkOnTerminalScene> _terminalFactory;
     private readonly IFactory<ISceneManager> _sceneManagerFactory;
     private readonly IFactory<PlayFrameworkHookRegistry> _registryFactory;
+    private readonly ILogger<PlayFrameworkBusinessManager> _logger;
+
+    // Ensures duplicate-registration warnings are logged at most once per instance.
+    private int _duplicateWarningsLogged = 0;
 
     private static readonly HashSet<AiResponseStatus> TerminalStatuses =
     [
@@ -33,13 +38,15 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
         IFactory<IPlayFrameworkAfterEachScene> afterFactory,
         IFactory<IPlayFrameworkOnTerminalScene> terminalFactory,
         IFactory<ISceneManager> sceneManagerFactory,
-        IFactory<PlayFrameworkHookRegistry> registryFactory)
+        IFactory<PlayFrameworkHookRegistry> registryFactory,
+        ILogger<PlayFrameworkBusinessManager> logger)
     {
         _beforeFactory = beforeFactory;
         _afterFactory = afterFactory;
         _terminalFactory = terminalFactory;
         _sceneManagerFactory = sceneManagerFactory;
         _registryFactory = registryFactory;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -53,6 +60,21 @@ internal sealed class PlayFrameworkBusinessManager : IPlayFrameworkBusinessManag
         businessActivity?.SetTag(PlayFrameworkActivitySource.Tags.FactoryName, factoryName);
 
         var registry = _registryFactory.Create(factoryName)!;
+
+        // Log duplicate-registration warnings once per manager instance.
+        if (System.Threading.Interlocked.Exchange(ref _duplicateWarningsLogged, 1) == 0)
+        {
+            foreach (var (hookImpl, priorities) in registry.DuplicateRegistrations)
+            {
+                _logger.LogWarning(
+                    "Hook type '{HookType}' is registered {Count} times for factory '{FactoryName}' " +
+                    "with priorities [{Priorities}]. All registrations are kept; verify this is intentional.",
+                    hookImpl.Name,
+                    priorities.Count,
+                    factoryName,
+                    string.Join(", ", priorities));
+            }
+        }
 
         // ── 1. BeforeExecution hooks ──────────────────────────────────────────
         var beforeHooks = registry

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkDenyResult.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkDenyResult.cs
@@ -2,13 +2,13 @@ namespace Rystem.PlayFramework;
 
 /// <summary>
 /// Carries the HTTP error information when a <see cref="IPlayFrameworkBeforeExecution"/> hook
-/// returns <see cref="PlayFrameworkGuardResult.Deny(int, string?)"/>.
+/// returns <see cref="PlayFrameworkGuardResult.Deny(int, object?)"/>.
 /// </summary>
 public sealed class PlayFrameworkDenyResult
 {
     /// <summary>HTTP status code to return to the client (e.g. 401, 403, 429).</summary>
     public int StatusCode { get; init; }
 
-    /// <summary>Human-readable error detail included in the response body.</summary>
-    public string? ErrorDetail { get; init; }
+    /// <summary>Error detail included in the response body. Can be a string or any serializable object.</summary>
+    public object? ErrorDetail { get; init; }
 }

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkDenyResult.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkDenyResult.cs
@@ -1,0 +1,14 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Carries the HTTP error information when a <see cref="IPlayFrameworkBeforeExecution"/> hook
+/// returns <see cref="PlayFrameworkGuardResult.Deny(int, string?)"/>.
+/// </summary>
+public sealed class PlayFrameworkDenyResult
+{
+    /// <summary>HTTP status code to return to the client (e.g. 401, 403, 429).</summary>
+    public int StatusCode { get; init; }
+
+    /// <summary>Human-readable error detail included in the response body.</summary>
+    public string? ErrorDetail { get; init; }
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkExecutionContext.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkExecutionContext.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Shared context passed to every hook in the same request pipeline.
+/// Constructed by <see cref="IPlayFrameworkBusinessManager"/> before executing hooks.
+/// </summary>
+public sealed class PlayFrameworkExecutionContext
+{
+    /// <summary>The user's text message.</summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// Multi-modal input (text + images/audio/files).
+    /// When set, the business manager calls <see cref="ISceneManager.ExecuteAsync(MultiModalInput,Dictionary{string,object}?,SceneRequestSettings?,CancellationToken)"/>
+    /// instead of the string overload.
+    /// </summary>
+    public MultiModalInput? Input { get; init; }
+
+    /// <summary>Conversation key from the request (can be null for new conversations).</summary>
+    public string? ConversationKey { get; init; }
+
+    /// <summary>
+    /// Request settings. Mutable — a <see cref="IPlayFrameworkBeforeExecution"/> hook can modify
+    /// these before they are passed to <see cref="ISceneManager.ExecuteAsync"/>.
+    /// </summary>
+    public SceneRequestSettings Settings { get; init; } = new();
+
+    /// <summary>
+    /// HTTP metadata built from the request (userId, ipAddress, requestId, timestamp, custom keys).
+    /// Passed directly to <see cref="ISceneManager.ExecuteAsync"/>.
+    /// </summary>
+    public Dictionary<string, object>? Metadata { get; init; }
+
+    /// <summary>
+    /// The authenticated user from the HTTP context.
+    /// <c>null</c> for unauthenticated requests.
+    /// Hook implementations read claim values via <c>User.FindFirst(...)</c>.
+    /// </summary>
+    public ClaimsPrincipal? User { get; init; }
+
+    /// <summary>
+    /// Thread-safe bag shared across all hooks in the same request.
+    /// Use this to pass data from one hook to another (e.g. cache key computed in
+    /// <see cref="IPlayFrameworkBeforeExecution"/> and consumed in <see cref="IPlayFrameworkAfterEachScene"/>).
+    /// </summary>
+    public ConcurrentDictionary<string, object> Items { get; init; } = new();
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkGuardResult.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkGuardResult.cs
@@ -1,0 +1,69 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Possible outcomes of a <see cref="IPlayFrameworkBeforeExecution"/> hook.
+/// </summary>
+public enum PlayFrameworkGuardResultType
+{
+    /// <summary>Execution proceeds to the next guard (or to the stream if last).</summary>
+    Allow,
+
+    /// <summary>Execution is blocked; the client receives an HTTP error response.</summary>
+    Deny,
+
+    /// <summary>Execution is short-circuited with a single synthetic SSE item.</summary>
+    ShortCircuit
+}
+
+/// <summary>
+/// Result returned by a <see cref="IPlayFrameworkBeforeExecution"/> hook.
+/// Use the static factory methods to create instances.
+/// </summary>
+public sealed class PlayFrameworkGuardResult
+{
+    /// <summary>The type of result.</summary>
+    public PlayFrameworkGuardResultType Type { get; }
+
+    /// <summary>
+    /// Non-null when <see cref="Type"/> is <see cref="PlayFrameworkGuardResultType.Deny"/>.
+    /// Contains the HTTP status code and optional error detail.
+    /// </summary>
+    public PlayFrameworkDenyResult? DenyResult { get; }
+
+    /// <summary>
+    /// Non-null when <see cref="Type"/> is <see cref="PlayFrameworkGuardResultType.ShortCircuit"/>.
+    /// The synthetic <see cref="AiSceneResponse"/> sent as the single SSE event.
+    /// </summary>
+    public AiSceneResponse? ShortCircuitResponse { get; }
+
+    private PlayFrameworkGuardResult(
+        PlayFrameworkGuardResultType type,
+        PlayFrameworkDenyResult? deny = null,
+        AiSceneResponse? shortCircuit = null)
+    {
+        Type = type;
+        DenyResult = deny;
+        ShortCircuitResponse = shortCircuit;
+    }
+
+    /// <summary>Allows execution to proceed to the next guard or to the stream.</summary>
+    public static PlayFrameworkGuardResult Allow()
+        => new(PlayFrameworkGuardResultType.Allow);
+
+    /// <summary>
+    /// Blocks execution; the endpoint returns the given HTTP status code with an optional error message.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code (e.g. 403, 429).</param>
+    /// <param name="errorDetail">Human-readable error detail.</param>
+    public static PlayFrameworkGuardResult Deny(int statusCode, string? errorDetail = null)
+        => new(PlayFrameworkGuardResultType.Deny,
+               deny: new PlayFrameworkDenyResult { StatusCode = statusCode, ErrorDetail = errorDetail });
+
+    /// <summary>
+    /// Short-circuits execution; the SSE stream is opened with a single synthetic item then closed.
+    /// Subsequent guards are skipped and <see cref="ISceneManager"/> is never called.
+    /// </summary>
+    /// <param name="response">The synthetic scene response to send.</param>
+    public static PlayFrameworkGuardResult ShortCircuit(AiSceneResponse response)
+        => new(PlayFrameworkGuardResultType.ShortCircuit, shortCircuit: response);
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkGuardResult.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkGuardResult.cs
@@ -51,11 +51,11 @@ public sealed class PlayFrameworkGuardResult
         => new(PlayFrameworkGuardResultType.Allow);
 
     /// <summary>
-    /// Blocks execution; the endpoint returns the given HTTP status code with an optional error message.
+    /// Blocks execution; the endpoint returns the given HTTP status code with an optional error detail.
     /// </summary>
     /// <param name="statusCode">HTTP status code (e.g. 403, 429).</param>
-    /// <param name="errorDetail">Human-readable error detail.</param>
-    public static PlayFrameworkGuardResult Deny(int statusCode, string? errorDetail = null)
+    /// <param name="errorDetail">Error detail included in the response body. Can be a string or any serializable object.</param>
+    public static PlayFrameworkGuardResult Deny(int statusCode, object? errorDetail = null)
         => new(PlayFrameworkGuardResultType.Deny,
                deny: new PlayFrameworkDenyResult { StatusCode = statusCode, ErrorDetail = errorDetail });
 

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookException.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookException.cs
@@ -1,0 +1,47 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Exception thrown when a business hook throws an unhandled exception.
+/// Wraps the original exception and carries context about which hook failed,
+/// in which pipeline phase, and at what priority level.
+/// </summary>
+public sealed class PlayFrameworkHookException : Exception
+{
+    /// <summary>
+    /// The <see cref="Type.Name"/> of the hook implementation that threw.
+    /// </summary>
+    public string HookTypeName { get; }
+
+    /// <summary>
+    /// The pipeline phase in which the hook was executing.
+    /// One of: "BeforeExecution", "AfterEachScene", "OnTerminalScene".
+    /// </summary>
+    public string Phase { get; }
+
+    /// <summary>
+    /// The priority value the hook was registered with (lower = runs first).
+    /// -1 when the priority could not be determined.
+    /// </summary>
+    public int Priority { get; }
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="PlayFrameworkHookException"/>.
+    /// </summary>
+    /// <param name="hookTypeName">Short type name of the failing hook.</param>
+    /// <param name="phase">Pipeline phase ("BeforeExecution" / "AfterEachScene" / "OnTerminalScene").</param>
+    /// <param name="priority">Registered priority of the hook, or -1 if unknown.</param>
+    /// <param name="innerException">The original exception thrown by the hook.</param>
+    public PlayFrameworkHookException(
+        string hookTypeName,
+        string phase,
+        int priority,
+        Exception innerException)
+        : base(
+            $"Hook '{hookTypeName}' threw an unhandled exception during phase '{phase}' (priority {priority}).",
+            innerException)
+    {
+        HookTypeName = hookTypeName;
+        Phase = phase;
+        Priority = priority;
+    }
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
@@ -15,15 +15,35 @@ public sealed class PlayFrameworkHookRegistry
     private Dictionary<Type, int> _rawPriorities = [];
 
     /// <summary>
+    /// Duplicate registrations detected at startup.
+    /// Each entry describes an implementation type that was registered more than once,
+    /// listing the priorities it was registered with.
+    /// Populated by <see cref="Build"/> and consumed by the business manager to emit warnings.
+    /// </summary>
+    internal IReadOnlyList<(Type HookImpl, IReadOnlyList<int> Priorities)> DuplicateRegistrations { get; private set; }
+        = [];
+
+    /// <summary>
     /// Builds the sorted position map from the full registration list.
     /// Called once by <see cref="Builder.PlayFrameworkBusinessBuilder.BuildRegistry"/> after
     /// all hooks have been registered, before the DI container is built.
     /// Equal-priority hooks preserve registration order (stable sort).
+    /// Detects duplicate implementation types (across all phases) and stores them in
+    /// <see cref="DuplicateRegistrations"/> for later logging.
     /// </summary>
     internal void Build(IReadOnlyList<(Type HookInterface, Type HookImpl, int Priority)> registrations)
     {
+        // Raw priorities (last registration wins for the map; all used in duplicate detection)
         _rawPriorities = registrations
             .ToDictionary(r => r.HookImpl, r => r.Priority);
+
+        // Detect duplicates: same HookImpl registered more than once (any phase)
+        var duplicates = registrations
+            .GroupBy(r => r.HookImpl)
+            .Where(g => g.Count() > 1)
+            .Select(g => (HookImpl: g.Key, Priorities: (IReadOnlyList<int>)g.Select(r => r.Priority).ToList()))
+            .ToList();
+        DuplicateRegistrations = duplicates;
 
         _sortedPositions = registrations
             .Select((r, registrationOrder) => (r.HookImpl, r.Priority, registrationOrder))

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
@@ -7,19 +7,45 @@ namespace Rystem.PlayFramework;
 /// </summary>
 public sealed class PlayFrameworkHookRegistry
 {
-    private readonly Dictionary<Type, int> _priorities = new();
+    // Pre-computed at startup: type → positional sort index (ascending priority,
+    // tiebroken by registration order so equal-priority hooks are stable).
+    private Dictionary<Type, int> _sortedPositions = [];
+
+    // Pre-computed at startup: type → raw registered priority value.
+    private Dictionary<Type, int> _rawPriorities = [];
 
     /// <summary>
-    /// Records the priority for a hook implementation type.
-    /// Called by <see cref="Builder.PlayFrameworkBusinessBuilder"/> during registration.
+    /// Builds the sorted position map from the full registration list.
+    /// Called once by <see cref="Builder.PlayFrameworkBusinessBuilder.BuildRegistry"/> after
+    /// all hooks have been registered, before the DI container is built.
+    /// Equal-priority hooks preserve registration order (stable sort).
     /// </summary>
-    internal void Register(Type hookImplementationType, int priority)
-        => _priorities[hookImplementationType] = priority;
+    internal void Build(IReadOnlyList<(Type HookInterface, Type HookImpl, int Priority)> registrations)
+    {
+        _rawPriorities = registrations
+            .ToDictionary(r => r.HookImpl, r => r.Priority);
+
+        _sortedPositions = registrations
+            .Select((r, registrationOrder) => (r.HookImpl, r.Priority, registrationOrder))
+            .OrderBy(x => x.Priority)
+            .ThenBy(x => x.registrationOrder)
+            .Select((x, position) => (x.HookImpl, position))
+            .ToDictionary(x => x.HookImpl, x => x.position);
+    }
+
+    /// <summary>
+    /// Returns the raw registered priority for the given hook implementation type,
+    /// or -1 if the type was not registered (e.g. a DI proxy/decorator).
+    /// </summary>
+    public int GetPriority(Type hookImplType)
+        => _rawPriorities.TryGetValue(hookImplType, out var p) ? p : -1;
 
     /// <summary>
     /// Returns the given hooks sorted ascending by their registered priority.
-    /// Hooks with no registered priority are treated as priority 0.
+    /// Equal-priority hooks run in their original registration order.
+    /// Hooks whose type is not in the registry (e.g. proxy-wrapped implementations)
+    /// are placed at the end of the sequence instead of silently receiving priority 0.
     /// </summary>
     public IEnumerable<T> SortByPriority<T>(IEnumerable<T> hooks) where T : notnull
-        => hooks.OrderBy(h => _priorities.TryGetValue(h.GetType(), out var p) ? p : 0);
+        => hooks.OrderBy(h => _sortedPositions.TryGetValue(h.GetType(), out var pos) ? pos : int.MaxValue);
 }

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
@@ -33,9 +33,11 @@ public sealed class PlayFrameworkHookRegistry
     /// </summary>
     internal void Build(IReadOnlyList<(Type HookInterface, Type HookImpl, int Priority)> registrations)
     {
-        // Raw priorities (last registration wins for the map; all used in duplicate detection)
+        // Raw priorities: first registration wins when the same type appears more than once.
+        // All occurrences are examined for duplicate detection regardless.
         _rawPriorities = registrations
-            .ToDictionary(r => r.HookImpl, r => r.Priority);
+            .GroupBy(r => r.HookImpl)
+            .ToDictionary(g => g.Key, g => g.First().Priority);
 
         // Detect duplicates: same HookImpl registered more than once (any phase)
         var duplicates = registrations
@@ -45,12 +47,22 @@ public sealed class PlayFrameworkHookRegistry
             .ToList();
         DuplicateRegistrations = duplicates;
 
-        _sortedPositions = registrations
+        // Sorted positions: compute once, use first (lowest) position when the same type
+        // appears multiple times so all instances of that type sort before any later type.
+        var sortedEntries = registrations
             .Select((r, registrationOrder) => (r.HookImpl, r.Priority, registrationOrder))
             .OrderBy(x => x.Priority)
             .ThenBy(x => x.registrationOrder)
             .Select((x, position) => (x.HookImpl, position))
-            .ToDictionary(x => x.HookImpl, x => x.position);
+            .ToList();
+
+        var positions = new Dictionary<Type, int>();
+        foreach (var (hookImpl, position) in sortedEntries)
+        {
+            // TryAdd: first (lowest sort index = highest priority) wins for duplicate types.
+            positions.TryAdd(hookImpl, position);
+        }
+        _sortedPositions = positions;
     }
 
     /// <summary>

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkHookRegistry.cs
@@ -1,0 +1,25 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Stores hook priority information for a single factory.
+/// Registered as a Singleton per factory name via
+/// <c>services.AddFactory(registry, factoryName, Singleton)</c>.
+/// </summary>
+public sealed class PlayFrameworkHookRegistry
+{
+    private readonly Dictionary<Type, int> _priorities = new();
+
+    /// <summary>
+    /// Records the priority for a hook implementation type.
+    /// Called by <see cref="Builder.PlayFrameworkBusinessBuilder"/> during registration.
+    /// </summary>
+    internal void Register(Type hookImplementationType, int priority)
+        => _priorities[hookImplementationType] = priority;
+
+    /// <summary>
+    /// Returns the given hooks sorted ascending by their registered priority.
+    /// Hooks with no registered priority are treated as priority 0.
+    /// </summary>
+    public IEnumerable<T> SortByPriority<T>(IEnumerable<T> hooks) where T : notnull
+        => hooks.OrderBy(h => _priorities.TryGetValue(h.GetType(), out var p) ? p : 0);
+}

--- a/src/AI/Rystem.PlayFramework/Business/PlayFrameworkSceneResult.cs
+++ b/src/AI/Rystem.PlayFramework/Business/PlayFrameworkSceneResult.cs
@@ -1,0 +1,72 @@
+namespace Rystem.PlayFramework;
+
+/// <summary>
+/// Possible outcomes of a <see cref="IPlayFrameworkAfterEachScene"/> hook.
+/// </summary>
+public enum PlayFrameworkSceneResultType
+{
+    /// <summary>The item (optionally modified) is forwarded to the SSE stream.</summary>
+    Forward,
+
+    /// <summary>The item is discarded; it is not sent to the client.</summary>
+    Suppress,
+
+    /// <summary>The item is forwarded and extra synthetic items are appended immediately after.</summary>
+    ForwardAndInject
+}
+
+/// <summary>
+/// Result returned by a <see cref="IPlayFrameworkAfterEachScene"/> hook.
+/// Use the static factory methods to create instances.
+/// </summary>
+public sealed class PlayFrameworkSceneResult
+{
+    /// <summary>The type of result.</summary>
+    public PlayFrameworkSceneResultType Type { get; }
+
+    /// <summary>
+    /// Non-null when <see cref="Type"/> is <see cref="PlayFrameworkSceneResultType.Forward"/>
+    /// or <see cref="PlayFrameworkSceneResultType.ForwardAndInject"/>.
+    /// The (possibly modified) scene response to send to the client.
+    /// </summary>
+    public AiSceneResponse? Scene { get; }
+
+    /// <summary>
+    /// Non-null when <see cref="Type"/> is <see cref="PlayFrameworkSceneResultType.ForwardAndInject"/>.
+    /// Extra items to append to the SSE stream after <see cref="Scene"/>.
+    /// These extra items bypass <see cref="IPlayFrameworkAfterEachScene"/> hooks.
+    /// </summary>
+    public AiSceneResponse[]? ExtraItems { get; }
+
+    private PlayFrameworkSceneResult(
+        PlayFrameworkSceneResultType type,
+        AiSceneResponse? scene = null,
+        AiSceneResponse[]? extra = null)
+    {
+        Type = type;
+        Scene = scene;
+        ExtraItems = extra;
+    }
+
+    /// <summary>
+    /// Forwards the (optionally modified) scene response to the client.
+    /// </summary>
+    /// <param name="scene">The scene to forward.</param>
+    public static PlayFrameworkSceneResult Forward(AiSceneResponse scene)
+        => new(PlayFrameworkSceneResultType.Forward, scene);
+
+    /// <summary>
+    /// Suppresses the scene response; it will not be written to the SSE stream.
+    /// </summary>
+    public static PlayFrameworkSceneResult Suppress()
+        => new(PlayFrameworkSceneResultType.Suppress);
+
+    /// <summary>
+    /// Forwards the scene response and appends extra synthetic items to the SSE stream.
+    /// The extra items bypass after-each-scene hooks.
+    /// </summary>
+    /// <param name="scene">The primary scene to forward.</param>
+    /// <param name="extra">Additional items to inject after <paramref name="scene"/>.</param>
+    public static PlayFrameworkSceneResult ForwardAndInject(AiSceneResponse scene, params AiSceneResponse[] extra)
+        => new(PlayFrameworkSceneResultType.ForwardAndInject, scene, extra);
+}

--- a/src/AI/Rystem.PlayFramework/Docs/BUSINESS_HOOKS_SPEC.md
+++ b/src/AI/Rystem.PlayFramework/Docs/BUSINESS_HOOKS_SPEC.md
@@ -1,0 +1,465 @@
+# PlayFramework Business Hooks — Specification
+
+**Versione**: 1.1  
+**Stato**: Aggiornato con vincolo architetturale Factory pattern  
+**Riferimento**: [PLAYFRAMEWORK_INTEGRATION_REQUEST.md](./PLAYFRAMEWORK_INTEGRATION_REQUEST.md)
+
+---
+
+## Obiettivo
+
+Aggiungere a `Rystem.PlayFramework` un sistema di hook/middleware per logica di business
+pre/post esecuzione, analogo a `IRepositoryBusinessBefore*` / `IRepositoryBusinessAfter*` di
+`Rystem.RepositoryFramework`. L'obiettivo finale è permettere la rimozione del controller custom
+(`AiController`) nei progetti consumer (es. TimeVision) delegando tutta la logica a
+`MapPlayFramework`.
+
+---
+
+## Vincolo architetturale — Factory pattern di `Rystem.DependencyInjection`
+
+**Tutto in PlayFramework è registrato e risolto tramite il factory pattern di
+`Rystem.DependencyInjection`.** Questo vincolo si applica anche agli hook di business.
+
+### Come funziona il factory pattern
+
+La registrazione avviene con:
+```csharp
+services.AddFactory<TInterface, TImplementation>(name, ServiceLifetime);
+```
+
+La chiave interna nel DI keyed-services è normalizzata in:
+```
+"Rystem.Factory.{typeof(TInterface).FullName}.{name}"
+```
+
+La risoluzione avviene con:
+```csharp
+IFactory<TInterface>.Create(factoryName)        // una istanza
+IFactory<TInterface>.CreateAll(factoryName)     // tutte le istanze registrate con quel nome
+```
+
+Il `factoryName` scorre da `AddPlayFramework("default", ...)` → `PlayFrameworkBuilder.Name` →
+`AddFactory(..., Name, ...)` → `IFactory<T>.Create(factoryName)` nell'endpoint handler.
+
+### Come va applicato agli hook
+
+Ogni tipo di hook è un servizio factory-keyed per `factoryName`:
+
+```csharp
+// Registrazione (dentro PlayFrameworkBusinessBuilder)
+services.AddFactory<IPlayFrameworkBeforeExecution, FeatureFlagGuard>(factoryName, Scoped);
+services.AddFactory<IPlayFrameworkBeforeExecution, RateLimitGuard>(factoryName, Scoped);
+services.AddFactory<IPlayFrameworkAfterEachScene, CostTrackingInterceptor>(factoryName, Scoped);
+services.AddFactory<IPlayFrameworkOnTerminalScene, UsageWarningHook>(factoryName, Scoped);
+
+// Registrazione del motore factory (una volta sola, in AddPlayFramework)
+services.AddEngineFactory<IPlayFrameworkBeforeExecution>();
+services.AddEngineFactory<IPlayFrameworkAfterEachScene>();
+services.AddEngineFactory<IPlayFrameworkOnTerminalScene>();
+services.AddEngineFactory<IPlayFrameworkBusinessManager>();
+```
+
+```csharp
+// Risoluzione a runtime (nell'endpoint handler o nel business manager)
+var beforeHooks = beforeExecutionFactory.CreateAll(factoryName); // tutti i guard per questa factory
+var afterHooks  = afterEachSceneFactory.CreateAll(factoryName);
+var terminalHooks = onTerminalFactory.CreateAll(factoryName);
+```
+
+`CreateAll(factoryName)` restituisce tutte le implementazioni registrate per quel nome, nell'ordine
+di registrazione — che poi viene riordinato per `priority`.
+
+### `IPlayFrameworkBusinessManager` è anch'esso factory-keyed
+
+Il manager stesso viene registrato e risolto per factory name:
+
+```csharp
+// Registrazione
+services.AddFactory<IPlayFrameworkBusinessManager, PlayFrameworkBusinessManager>(factoryName, Scoped);
+services.AddEngineFactory<IPlayFrameworkBusinessManager>();
+
+// Risoluzione nell'endpoint handler
+var manager = businessManagerFactory.Create(factoryName);
+```
+
+Se nessun hook è registrato per una factory, `CreateAll` ritorna una lista vuota e il manager
+comporta come se non ci fossero hook (esecuzione diretta, nessun pre/post processing).
+
+---
+
+## Decisioni di design
+
+### 1. Registrazione — dentro `AddPlayFramework`
+
+Gli hook si registrano tramite una lambda `business` dentro il builder di `AddPlayFramework`,
+nello stesso punto dove vengono configurate le altre impostazioni della factory.
+
+```csharp
+services.AddPlayFramework("default", config =>
+{
+    // configurazione esistente ...
+    config.Business
+        .AddBeforeExecution<FeatureFlagGuard>()
+        .AddBeforeExecution<RateLimitGuard>(priority: 1)
+        .AddAfterEachScene<CostTrackingInterceptor>()
+        .AddOnTerminalScene<UsageWarningHook>();
+});
+```
+
+Non esiste un metodo separato `AddPlayFrameworkBusiness`. La registrazione è inline nel builder.
+
+`PlayFrameworkBusinessBuilder` riceve `IServiceCollection` e `factoryName` da `PlayFrameworkBuilder`
+e chiama `AddFactory<TInterface, TImpl>(factoryName, Scoped)` per ogni hook registrato.
+
+### 2. Scoping per factory name
+
+Ogni istanza di `MapPlayFramework` (identificata da `factoryName`) ha il proprio set di hook.
+Hook registrati per `"default"` non si applicano a `"premium"` e viceversa. Questo permette
+logiche di rate limiting o feature flag differenziate per factory.
+
+Lo scoping è garantito automaticamente dal factory pattern: `AddFactory<T, TImpl>(name)` registra
+il servizio sotto la chiave `"Rystem.Factory.{T}.{name}"`, quindi hook di factory diverse non
+collidono mai.
+
+### 3. DI lifetime — Scoped
+
+Gli hook sono registrati come `Scoped` nel DI container tramite
+`AddFactory<TInterface, TImpl>(factoryName, ServiceLifetime.Scoped)`.
+Una nuova istanza viene creata per ogni richiesta HTTP. Questo consente agli hook di iniettare
+servizi scoped (es. `DbContext`, `ICacheService`) via costruttore.
+
+```csharp
+public sealed class RateLimitGuard(ICacheService cacheService, ILogger<RateLimitGuard> logger)
+    : IPlayFrameworkBeforeExecution
+{
+    public async Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        // ...
+    }
+}
+```
+
+### 4. Molteplicità — pipeline ordinata per Priority
+
+Più implementazioni dello stesso tipo di hook possono coesistere. Vengono eseguite in sequenza,
+ordinate per `priority` (valore intero, ascending). A parità di priority, l'ordine è quello di
+registrazione.
+
+**Priority**: parametro opzionale, default `0`. Viene memorizzato in una struttura wrapper
+insieme al tipo dell'hook durante la registrazione, poi usato per ordinare prima di eseguire.
+
+La chiamata `IFactory<IPlayFrameworkBeforeExecution>.CreateAll(factoryName)` restituisce già
+tutte le implementazioni nell'ordine di registrazione; il business manager le riordina per
+priority prima di eseguirle.
+
+In `BeforeExecution`: se un guard restituisce `Deny` o `ShortCircuit`, i guard successivi non
+vengono eseguiti (short-circuit della pipeline).
+
+### 5. Orchestratore — `IPlayFrameworkBusinessManager`
+
+Un servizio `IPlayFrameworkBusinessManager` (Scoped, factory-keyed) coordina l'intera pipeline.
+L'endpoint handler SSE in `WebApplicationExtensions.cs` risolve il manager tramite
+`IFactory<IPlayFrameworkBusinessManager>.Create(factoryName)` e gli delega l'esecuzione.
+
+Il manager inietta nel costruttore:
+- `IFactory<IPlayFrameworkBeforeExecution>` → chiama `CreateAll(factoryName)`
+- `IFactory<IPlayFrameworkAfterEachScene>` → chiama `CreateAll(factoryName)`
+- `IFactory<IPlayFrameworkOnTerminalScene>` → chiama `CreateAll(factoryName)`
+- `IFactory<ISceneManager>` → chiama `Create(factoryName)`
+
+Il `factoryName` viene passato al manager come parametro (non iniettato): l'endpoint handler lo
+conosce già (dal route o dalla configurazione) e lo passa al momento della chiamata.
+
+Responsabilità del manager:
+1. Costruire `PlayFrameworkExecutionContext`
+2. Applicare il timeout (LinkedCancellationTokenSource)
+3. Eseguire gli hook `BeforeExecution` in sequenza (ordinati per priority)
+4. Gestire il risultato del guard (Allow / Deny / ShortCircuit)
+5. Chiamare `ISceneManager.ExecuteAsync`
+6. Per ogni item dello stream: eseguire gli hook `AfterEachScene` (ordinati per priority)
+7. Al termine: eseguire gli hook `OnTerminalScene` (ordinati per priority)
+
+Il manager espone:
+```csharp
+public interface IPlayFrameworkBusinessManager
+{
+    IAsyncEnumerable<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)> ExecuteAsync(
+        string factoryName,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+L'endpoint handler SSE itera il risultato e scrive gli item SSE direttamente su `HttpResponse`.
+
+### 6. Gestione errori — propagazione
+
+Le eccezioni non gestite lanciate dagli hook si propagano verso l'endpoint handler, che risponde
+con `500 Internal Server Error`. Non esiste un hook `OnError` dedicato.
+
+---
+
+## Hook interfaces
+
+### `IPlayFrameworkBeforeExecution`
+
+Gira **una volta** prima che lo stream parta. Può bloccare l'esecuzione o lasciarla procedere.
+
+```csharp
+public interface IPlayFrameworkBeforeExecution
+{
+    Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Risultati possibili:**
+
+| Risultato | Comportamento |
+|-----------|---------------|
+| `PlayFrameworkGuardResult.Allow()` | L'esecuzione procede al guard successivo (o allo stream se è l'ultimo) |
+| `PlayFrameworkGuardResult.Deny(statusCode, errorDetail)` | Lo stream non parte. Il client riceve un HTTP error (es. 403). I guard successivi non girano. |
+| `PlayFrameworkGuardResult.ShortCircuit(AiSceneResponse)` | Lo stream SSE viene aperto, viene inviato il singolo item sintetico, poi si chiude. I guard successivi non girano. |
+
+**Note su `ShortCircuit`**: il server apre il flusso SSE (`text/event-stream`) e invia un singolo
+evento `data: {...}\n\n`, poi chiude la connessione. Il client SSE riceve sempre SSE,
+indipendentemente dal percorso, garantendo coerenza di protocollo.
+
+**Caso d'uso TimeVision**:
+- `FeatureFlagGuard`: controlla `IFeatureManager.IsEnabledAsync` + `IFeatureFlagService` →
+  `Deny(403)` se AI non abilitata
+- `RateLimitGuard`: legge il costo accumulato da cache → `ShortCircuit(BuildUsageLimitExceededResponse())`
+  se soglia superata
+
+---
+
+### `IPlayFrameworkAfterEachScene`
+
+Gira **per ogni `AiSceneResponse`** prodotta dallo stream, prima che venga scritta sul canale SSE.
+
+```csharp
+public interface IPlayFrameworkAfterEachScene
+{
+    Task<PlayFrameworkSceneResult> AfterSceneAsync(
+        AiSceneResponse scene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Risultati possibili:**
+
+| Risultato | Comportamento |
+|-----------|---------------|
+| `PlayFrameworkSceneResult.Forward(scene)` | L'item (eventualmente modificato) viene inviato al client |
+| `PlayFrameworkSceneResult.Suppress()` | L'item non viene inviato al client |
+| `PlayFrameworkSceneResult.ForwardAndInject(scene, AiSceneResponse[] extra)` | L'item viene inviato, poi vengono inviati gli item `extra` in sequenza |
+
+**Note**: la pipeline di hook `AfterEachScene` si applica anche agli item `extra` iniettati
+tramite `ForwardAndInject`? **No** — gli item extra vengono inviati direttamente senza passare
+per gli hook, per evitare loop infiniti.
+
+**Caso d'uso TimeVision**:
+- Skip `AiResponseStatus.ToolSkipped` → `Suppress()`
+- Rename Summarizing → `Forward(scene con SceneName modificato)`
+- Soppressione messaggi con prefix specifico → `Suppress()`
+- Cost tracking: `cacheService.IncrementAsync(...)` come side-effect, poi `Forward(scene)`
+- Logging per ogni risposta come side-effect
+
+---
+
+### `IPlayFrameworkOnTerminalScene`
+
+Gira **una volta** quando viene rilevato uno status terminale
+(`Completed | Error | BudgetExceeded | Unauthorized`).
+
+La risposta terminale viene **prima inviata al client**, poi gli hook `OnTerminalScene` girano e
+possono iniettare item aggiuntivi **in coda** al flusso SSE.
+
+```csharp
+public interface IPlayFrameworkOnTerminalScene
+{
+    Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+        AiSceneResponse terminalScene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+**Ritorno**: `null` o lista vuota = nessuna iniezione. Lista non-null = gli item vengono inviati
+al client in sequenza dopo la risposta terminale.
+
+Più hook `OnTerminalScene` girano in sequenza (pipeline); gli item iniettati da ciascun hook
+vengono accodati nell'ordine degli hook.
+
+**Caso d'uso TimeVision**: calcolo costo accumulato da cache; se supera la soglia configurata,
+inietta un item `BuildUsageWarningResponse(...)` dopo il terminale.
+
+---
+
+## `PlayFrameworkExecutionContext`
+
+Contesto condiviso tra tutti gli hook della stessa richiesta. Viene costruito dall'orchestratore
+prima dell'esecuzione e passato a ogni hook.
+
+```csharp
+public sealed class PlayFrameworkExecutionContext
+{
+    /// Messaggio dell'utente
+    public string Message { get; init; }
+
+    /// Chiave conversazione (da request)
+    public string? ConversationKey { get; init; }
+
+    /// Settings della richiesta — mutable: BeforeExecution può modificarle
+    /// prima che vengano passate a ISceneManager.ExecuteAsync
+    public SceneRequestSettings Settings { get; init; }
+
+    /// ClaimsPrincipal dell'utente autenticato (da HttpContext.User).
+    /// Null se la richiesta non è autenticata.
+    /// I claim type sono project-specific; gli hook li leggono con User.FindFirst(...)
+    public ClaimsPrincipal? User { get; init; }
+
+    /// Bag condiviso tra hook della stessa richiesta.
+    /// Usato per passare dati calcolati da un hook (es. cache key) agli hook successivi.
+    /// ConcurrentDictionary per sicurezza in scenari async.
+    public ConcurrentDictionary<string, object> Items { get; init; }
+}
+```
+
+**Pattern Items bag** (esempio TimeVision):
+```csharp
+// In RateLimitGuard.BeforeExecutionAsync:
+var cacheKey = BuildCacheKey(tenantId, userId, month);
+context.Items["usageCacheKey"] = cacheKey;
+
+// In CostTrackingInterceptor.AfterSceneAsync:
+var cacheKey = (string)context.Items["usageCacheKey"];
+await cacheService.IncrementAsync(cacheKey, cost, cancellationToken);
+```
+
+**Nota**: `IServiceProvider` non è esposto nel context. Gli hook ricevono le dipendenze via
+costruttore (DI scoped standard).
+
+---
+
+## Timeout per-richiesta
+
+**Configurazione**: `PlayFrameworkApiSettings.TimeoutInSeconds` (server-side, non modificabile
+dal client).
+
+```csharp
+app.MapPlayFramework("default", settings =>
+{
+    settings.BasePath = "/api/completions";
+    settings.TimeoutInSeconds = 60;
+});
+```
+
+**Scope del timeout**: copre l'intera pipeline — da `BeforeExecution` fino al completamento degli
+hook `OnTerminalScene`.
+
+**Implementazione**: il business manager crea un `CancellationTokenSource` con il timeout
+configurato e lo linka al token della richiesta HTTP (`CancellationTokenSource.CreateLinkedTokenSource`).
+Tutti gli hook e `ISceneManager.ExecuteAsync` ricevono il token linkato.
+
+**Comportamento in caso di timeout**: `408 Request Timeout`. La distinzione tra timeout scaduto
+e cancellazione da parte del client avviene tramite `when (timeoutCts.IsCancellationRequested)`
+come nel controller originale.
+
+---
+
+## Flusso di esecuzione completo
+
+```
+POST /api/completions
+       │
+       ▼
+[IPlayFrameworkBusinessManager.ExecuteAsync]
+       │
+       ├─ Costruisce PlayFrameworkExecutionContext
+       ├─ Crea timeoutCts (se TimeoutInSeconds > 0) + linkedCts
+       │
+       ├─ [BeforeExecution hooks] (in ordine di priority)
+       │      ├─ Allow → continua al prossimo hook
+       │      ├─ Deny → scrive HTTP error, return
+       │      └─ ShortCircuit → apre SSE, scrive 1 item, chiude, return
+       │
+       ├─ ISceneManager.ExecuteAsync(message, settings, linkedCts)
+       │      │
+       │      └─ await foreach AiSceneResponse
+       │             │
+       │             ├─ [AfterEachScene hooks] (in ordine di priority)
+       │             │      ├─ Forward(scene) → scrivi su SSE
+       │             │      ├─ Suppress() → skip
+       │             │      └─ ForwardAndInject(scene, extra[]) → scrivi scene + extra
+       │             │
+       │             └─ se status terminale:
+       │                    ├─ scrivi item terminale su SSE (già fatto sopra se Forward)
+       │                    └─ [OnTerminalScene hooks] (in ordine di priority)
+       │                           └─ inietta item extra su SSE
+       │
+       └─ Chiude lo stream SSE
+```
+
+---
+
+## Builder API — shape definitiva
+
+```csharp
+// Registrazione (dentro AddPlayFramework)
+services.AddPlayFramework("default", config =>
+{
+    config.DefaultExecutionMode = SceneExecutionMode.DynamicChaining;
+
+    config.Business
+        .AddBeforeExecution<FeatureFlagGuard>()
+        .AddBeforeExecution<RateLimitGuard>(priority: 1)
+        .AddAfterEachScene<CostTrackingInterceptor>()
+        .AddOnTerminalScene<UsageWarningHook>();
+});
+
+// Mapping endpoint (invariato)
+app.MapPlayFramework("default", settings =>
+{
+    settings.BasePath = "/api/completions";
+    settings.TimeoutInSeconds = 60;
+    settings.EnableConversationEndpoints = true;
+});
+```
+
+---
+
+## Priorità implementazione
+
+| Componente | Priorità | Blocca rimozione AiController |
+|---|---|---|
+| `IPlayFrameworkBeforeExecution` + `PlayFrameworkGuardResult` | Alta | Sì |
+| `IPlayFrameworkAfterEachScene` + `PlayFrameworkSceneResult` | Alta | Sì |
+| `PlayFrameworkExecutionContext` | Alta | Sì |
+| `IPlayFrameworkBusinessManager` (orchestratore) | Alta | Sì |
+| `IPlayFrameworkOnTerminalScene` | Media | Sì (per usage warning) |
+| `PlayFrameworkApiSettings.TimeoutInSeconds` | Bassa | No (gestibile fuori) |
+
+---
+
+## Note implementative
+
+- **Status terminali**: `AiResponseStatus.Completed | Error | BudgetExceeded | Unauthorized`
+- **Item extra di `ForwardAndInject` e `OnTerminalScene`**: non passano per gli hook `AfterEachScene`
+- **Hook `AfterEachScene` su item soppressi**: se un hook sopprime un item ma quello stesso item
+  ha status terminale, `OnTerminalScene` gira comunque (il trigger è lo status, non l'invio al client)
+- **Nessuna scansione automatica assembly**: gli hook si registrano esplicitamente nel builder,
+  non tramite `Scan*`. Questo è intenzionale per mantenere la registrazione visibile e controllata.
+- **Factory senza hook**: se nessun hook è registrato per una factory, `CreateAll` ritorna lista
+  vuota e il manager esegue direttamente `ISceneManager.ExecuteAsync` senza overhead. Il
+  `IPlayFrameworkBusinessManager` va comunque registrato come factory anche in assenza di hook,
+  perché è lui che gestisce il timeout.
+- **Priority storage**: la priority non è sull'interfaccia hook (a differenza di
+  `IRepositoryBusiness.Priority`). Viene memorizzata in una struttura interna di
+  `PlayFrameworkBusinessBuilder` durante la registrazione e trasferita al manager tramite
+  `IPlayFrameworkHookRegistry` (o equivalente) registrato come singleton per factory name.

--- a/src/AI/Rystem.PlayFramework/Domain/Enums/AiResponseStatus.cs
+++ b/src/AI/Rystem.PlayFramework/Domain/Enums/AiResponseStatus.cs
@@ -123,5 +123,17 @@ public enum AiResponseStatus
     /// <summary>
     /// Indicates that the request was not authorized.
     /// </summary>
-    Unauthorized
+    Unauthorized,
+
+    /// <summary>
+    /// The server-side timeout expired before the pipeline completed.
+    /// A synthetic SSE item with this status is emitted at the end of the stream
+    /// so clients can detect and handle the timeout gracefully.
+    /// </summary>
+    Timeout,
+
+    /// <summary>
+    /// The request was rate-limited (e.g., by a BeforeExecution hook or an upstream LLM provider).
+    /// </summary>
+    RateLimited
 }

--- a/src/AI/Rystem.PlayFramework/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AI/Rystem.PlayFramework/Extensions/ServiceCollectionExtensions.cs
@@ -70,6 +70,18 @@ public static class ServiceCollectionExtensions
         services.AddEngineFactory<IRateLimiter>();  // Add rate limiter factory (optional, but DI needs it registered)
         services.AddEngineFactory<IVoiceAdapter>();  // Add voice adapter factory (optional, registered by adapter packages)
 
+        // Business hook engine factories (always registered; no-op when no hooks are configured)
+        services.AddEngineFactory<IPlayFrameworkBeforeExecution>();
+        services.AddEngineFactory<IPlayFrameworkAfterEachScene>();
+        services.AddEngineFactory<IPlayFrameworkOnTerminalScene>();
+        services.AddEngineFactory<IPlayFrameworkBusinessManager>();
+        services.AddEngineFactory<PlayFrameworkHookRegistry>();
+
+        // Build business hook registry + register IPlayFrameworkBusinessManager factory.
+        // This is a no-op if the user never called config.Business.Add*() — the registry
+        // will simply be empty and the manager will pass through to ISceneManager directly.
+        builder.BuildBusinessRegistry();
+
         // Add repository factory (optional, registered only if user calls UseRepository())
         if (builder.HasRepository)
         {

--- a/src/AI/Rystem.PlayFramework/README.md
+++ b/src/AI/Rystem.PlayFramework/README.md
@@ -1210,6 +1210,177 @@ Response cost fields:
 | `AiSceneResponse.OutputTokens` | output tokens generated in this call |
 | `AiSceneResponse.CachedInputTokens` | cached input tokens used in this call |
 
+## Example: business hooks (BeforeExecution, AfterEachScene, OnTerminalScene)
+
+Business hooks let you plug cross-cutting logic into the PlayFramework execution pipeline without modifying your scenes. There are three hook types, each addressing a different phase:
+
+| Hook interface | Phase | Typical use cases |
+| --- | --- | --- |
+| `IPlayFrameworkBeforeExecution` | Before the stream starts | Rate limiting, auth checks, prompt injection |
+| `IPlayFrameworkAfterEachScene` | After each `AiSceneResponse` is produced | Cost tracking, response filtering, audit logging |
+| `IPlayFrameworkOnTerminalScene` | When a terminal status is detected | Session finalization, usage recording, async notifications |
+
+### Registration
+
+Hooks are registered on `builder.Business` inside the `AddPlayFramework` configure lambda:
+
+```csharp
+builder.Services.AddPlayFramework("default", framework =>
+{
+    framework
+        .WithChatClient("default")
+        .AddScene("Assistant", "General conversation", _ => { });
+
+    framework.Business
+        .AddBeforeExecution<RateLimitHook>(priority: 0)
+        .AddBeforeExecution<AuditLogHook>(priority: 10)
+        .AddAfterEachScene<CostAccumulatorHook>(priority: 0)
+        .AddOnTerminalScene<SessionFinalizerHook>(priority: 0);
+});
+
+// Hook implementations are resolved from DI (Scoped per request)
+builder.Services.AddScoped<IRateLimitService, RateLimitService>();
+```
+
+The `priority` parameter controls execution order within each hook type — **lower numbers run first**. All three types accept any number of registered implementations.
+
+### IPlayFrameworkBeforeExecution
+
+Called once before the SSE stream opens. Return one of three outcomes:
+
+```csharp
+public sealed class RateLimitHook : IPlayFrameworkBeforeExecution
+{
+    private readonly IRateLimitService _rateLimiter;
+
+    public RateLimitHook(IRateLimitService rateLimiter) => _rateLimiter = rateLimiter;
+
+    public async Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var userId = context.User?.FindFirst("sub")?.Value ?? "anonymous";
+        var allowed = await _rateLimiter.TryAcquireAsync(userId, cancellationToken);
+
+        if (!allowed)
+            return PlayFrameworkGuardResult.Deny(429, "Rate limit exceeded. Try again later.");
+
+        // Store data for downstream hooks via the shared Items bag
+        context.Items["userId"] = userId;
+        return PlayFrameworkGuardResult.Allow();
+    }
+}
+```
+
+| Return value | Effect |
+| --- | --- |
+| `PlayFrameworkGuardResult.Allow()` | Proceeds to the next hook (or starts the stream) |
+| `PlayFrameworkGuardResult.Deny(statusCode, detail)` | Endpoint returns the given HTTP error; stream never opens |
+| `PlayFrameworkGuardResult.ShortCircuit(response)` | Stream opens with one synthetic SSE item then closes; `ISceneManager` is never called |
+
+### IPlayFrameworkAfterEachScene
+
+Called for every `AiSceneResponse` emitted by the scene manager, before it is written to the SSE channel:
+
+```csharp
+public sealed class CostAccumulatorHook : IPlayFrameworkAfterEachScene
+{
+    private readonly ICostRepository _repo;
+
+    public CostAccumulatorHook(ICostRepository repo) => _repo = repo;
+
+    public async Task<PlayFrameworkSceneResult> AfterSceneAsync(
+        AiSceneResponse scene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (scene.Cost is not null)
+        {
+            var userId = context.Items.TryGetValue("userId", out var u) ? (string)u : "anonymous";
+            await _repo.AccumulateAsync(userId, scene.Cost.Value, cancellationToken);
+        }
+
+        return PlayFrameworkSceneResult.Forward(scene);
+    }
+}
+```
+
+| Return value | Effect |
+| --- | --- |
+| `PlayFrameworkSceneResult.Forward(scene)` | Sends the (optionally modified) item to the client |
+| `PlayFrameworkSceneResult.Suppress()` | Discards the item; client never receives it |
+| `PlayFrameworkSceneResult.ForwardAndInject(scene, extras)` | Sends the item, then appends extra synthetic items (extras bypass AfterEachScene hooks) |
+
+### IPlayFrameworkOnTerminalScene
+
+Called once when a terminal status is detected (`Completed`, `Error`, `BudgetExceeded`, `Unauthorized`). The terminal response is always sent to the client first; items returned by this hook are appended to the stream afterwards and bypass `IPlayFrameworkAfterEachScene` hooks:
+
+```csharp
+public sealed class SessionFinalizerHook : IPlayFrameworkOnTerminalScene
+{
+    private readonly ISessionRepository _sessions;
+
+    public SessionFinalizerHook(ISessionRepository sessions) => _sessions = sessions;
+
+    public async Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+        AiSceneResponse terminalScene,
+        PlayFrameworkExecutionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var userId = context.Items.TryGetValue("userId", out var u) ? (string)u : "anonymous";
+        var summary = await _sessions.FinalizeAsync(userId, terminalScene.Status, cancellationToken);
+
+        // Optionally inject a summary item into the SSE stream after the terminal response
+        return
+        [
+            new AiSceneResponse
+            {
+                Status = AiResponseStatus.FinalResponse,
+                Message = $"Session finalized. Total cost: {summary.TotalCost:F4} USD."
+            }
+        ];
+    }
+}
+```
+
+Return `null` or an empty enumerable when no additional items are needed.
+
+### PlayFrameworkExecutionContext
+
+Every hook in the same request receives the same `PlayFrameworkExecutionContext` instance:
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `Message` | `string` | The user's text message |
+| `Input` | `MultiModalInput?` | Multi-modal input (text + images/audio/files), if used |
+| `ConversationKey` | `string?` | Conversation key from the request (null for new conversations) |
+| `Settings` | `SceneRequestSettings` | Per-request settings — mutable, can be modified by BeforeExecution hooks |
+| `Metadata` | `Dictionary<string, object>?` | HTTP metadata (userId, ipAddress, requestId, timestamp, custom keys) |
+| `User` | `ClaimsPrincipal?` | The authenticated user (null for unauthenticated requests) |
+| `Items` | `ConcurrentDictionary<string, object>` | Thread-safe bag for passing data between hooks in the same request |
+
+### Timeout
+
+A per-request timeout can be configured in `PlayFrameworkApiSettings`:
+
+```csharp
+builder.Services.Configure<PlayFrameworkApiSettings>(options =>
+{
+    options.TimeoutInSeconds = 30; // abort streaming after 30 s
+});
+```
+
+When the timeout fires, the endpoint returns HTTP 504 and the SSE connection is closed.
+
+Important behavior:
+
+- All three hook types are resolved from the DI container as **Scoped** services — one instance per HTTP request.
+- Hooks of the same type run in ascending `priority` order. Hooks with equal priority run in registration order.
+- `IPlayFrameworkBusinessManager` is always registered, even when no hooks are configured (it handles the timeout and delegates to `ISceneManager` transparently).
+- `ForwardAndInject` extra items and `OnTerminalScene` injected items **bypass** `IPlayFrameworkAfterEachScene` hooks to prevent infinite loops.
+- `OnTerminalScene` fires based on the **original** response status, even if the triggering item was suppressed by an `AfterEachScene` hook.
+- A `BeforeExecution` hook can mutate `context.Settings` (e.g. inject `ForcedTools` or change `MaxBudget`) before execution begins.
+
 ## Example: custom extensibility
 
 Core pipeline components can be swapped out without forking the framework.

--- a/src/AI/Rystem.PlayFramework/README.md
+++ b/src/AI/Rystem.PlayFramework/README.md
@@ -1313,7 +1313,7 @@ public sealed class CostAccumulatorHook : IPlayFrameworkAfterEachScene
 
 ### IPlayFrameworkOnTerminalScene
 
-Called once when a terminal status is detected (`Completed`, `Error`, `BudgetExceeded`, `Unauthorized`). The terminal response is always sent to the client first; items returned by this hook are appended to the stream afterwards and bypass `IPlayFrameworkAfterEachScene` hooks:
+Called once when a terminal status is detected (`Completed`, `Error`, `BudgetExceeded`, `Unauthorized`, `Timeout`, `RateLimited`). The terminal response is always sent to the client first; items returned by this hook are appended to the stream afterwards and bypass `IPlayFrameworkAfterEachScene` hooks:
 
 ```csharp
 public sealed class SessionFinalizerHook : IPlayFrameworkOnTerminalScene
@@ -1370,7 +1370,10 @@ builder.Services.Configure<PlayFrameworkApiSettings>(options =>
 });
 ```
 
-When the timeout fires, the endpoint returns HTTP 504 and the SSE connection is closed.
+When the timeout fires:
+
+- If the SSE stream has **not yet started**: the endpoint returns HTTP 504 and the connection is closed.
+- If the SSE stream **is already open**: a synthetic `AiResponseStatus.Timeout` item is emitted into the stream before the connection closes, so clients can detect and handle the timeout gracefully.
 
 Important behavior:
 
@@ -1380,6 +1383,8 @@ Important behavior:
 - `ForwardAndInject` extra items and `OnTerminalScene` injected items **bypass** `IPlayFrameworkAfterEachScene` hooks to prevent infinite loops.
 - `OnTerminalScene` fires based on the **original** response status, even if the triggering item was suppressed by an `AfterEachScene` hook.
 - A `BeforeExecution` hook can mutate `context.Settings` (e.g. inject `ForcedTools` or change `MaxBudget`) before execution begins.
+- If a hook throws a non-cancellation exception it is wrapped in `PlayFrameworkHookException` (which carries `HookTypeName`, `Phase`, and `Priority`) and propagated — the pipeline does not silently swallow hook errors.
+- If the same hook implementation type is registered more than once, a `LogWarning` is emitted **once per `IPlayFrameworkBusinessManager` instance** at the first `ExecuteAsync` call, reporting the type name, registration count, factory name, and all registered priorities. All duplicate registrations are kept; no registration is silently dropped.
 
 ## Example: custom extensibility
 
@@ -1453,22 +1458,32 @@ All possible values of `AiResponseStatus`:
 
 | Status | Description |
 |---|---|
-| `Completed` | Execution finished successfully |
-| `Streaming` | Token-level streaming chunk in progress |
+| `Initializing` | Initializing execution context |
+| `LoadingCache` | Loading data from conversation cache |
+| `ExecutingMainActors` | Executing main actors |
+| `Planning` | Creating an execution plan |
 | `ExecutingScene` | Engine is inside a scene |
+| `ExecutingPlan` | Executing a plan step |
 | `FunctionRequest` | Server-side tool call started |
 | `FunctionCompleted` | Server-side tool call finished |
+| `ToolSkipped` | Tool execution skipped (already executed) |
 | `AwaitingClient` | Waiting for a client-side tool response |
 | `CommandClient` | Fire-and-forget command sent to client |
-| `Planning` | Creating an execution plan |
-| `ExecutingPlan` | Executing a plan step |
+| `Streaming` | Token-level streaming chunk in progress |
+| `Running` | General processing in progress |
 | `Summarizing` | Compressing conversation history |
-| `Directing` | Director evaluating scene output |
+| `DirectorDecision` | Director evaluating scene output |
+| `GeneratingFinalResponse` | Generating aggregated final response |
+| `FinalResponse` | Final aggregated response item |
+| `SavingCache` | Persisting response to conversation cache |
+| `SavingRepository` | Saving to conversation repository |
+| `SavingMemory` | Saving to memory layer |
+| `Completed` | Execution finished successfully |
 | `BudgetExceeded` | Request exceeded `MaxBudget` |
 | `Error` | Unhandled error during execution |
 | `Unauthorized` | `IAuthorizationLayer` rejected the request |
-| `RateLimited` | Rate limit exceeded with `RejectOnExceeded` |
-| `Cached` | Response served from conversation cache |
+| `Timeout` | Server-side timeout expired; synthetic SSE item emitted if stream was already open |
+| `RateLimited` | Rate limit exceeded (e.g. `RejectOnExceeded` or a `BeforeExecution` hook) |
 
 ## Important caveats
 

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -176,10 +176,9 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         foreach (var qp in _config.QueryParameters)
             skipNames.Add(qp.Name);
 
-        foreach (var kv in argsDict)
+        foreach (var kv in argsDict.Where(kv => !skipNames.Contains(kv.Key)))
         {
-            if (!skipNames.Contains(kv.Key))
-                bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
+            bodyNode[kv.Key] = JsonNode.Parse(kv.Value.GetRawText());
         }
 
         var bodyJson = bodyNode.ToJsonString();
@@ -255,8 +254,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
             ["properties"] = properties
         };
 
-        if (required.Count > 0)
-            schema["required"] = required;
+        schema["required"] = required;
 
         return JsonSerializer.Deserialize<JsonElement>(schema.ToJsonString());
     }

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -6,7 +6,6 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
-using Rystem.PlayFramework.Helpers;
 
 namespace Rystem.PlayFramework;
 

--- a/src/AI/Rystem.PlayFramework/Telemetry/PlayFrameworkActivitySource.cs
+++ b/src/AI/Rystem.PlayFramework/Telemetry/PlayFrameworkActivitySource.cs
@@ -87,6 +87,11 @@ public static class PlayFrameworkActivitySource
         public const string McpToolCount = "playframework.mcp.tool_count";
         public const string McpResourceCount = "playframework.mcp.resource_count";
         public const string McpPromptCount = "playframework.mcp.prompt_count";
+
+        // Business hook tags
+        public const string HookType = "playframework.hook.type";
+        public const string HookOutcome = "playframework.hook.outcome";
+        public const string HookPriority = "playframework.hook.priority";
     }
     
     /// <summary>
@@ -132,6 +137,11 @@ public static class PlayFrameworkActivitySource
         public const string McpToolCalled = "mcp.tool_called";
         public const string McpToolCompleted = "mcp.tool_completed";
         public const string McpToolFailed = "mcp.tool_failed";
+
+        // Business hook events
+        public const string HookDenied = "hook.denied";
+        public const string HookShortCircuited = "hook.short_circuited";
+        public const string HookSuppressed = "hook.suppressed";
     }
     
     /// <summary>
@@ -173,5 +183,11 @@ public static class PlayFrameworkActivitySource
         public const string McpLoadResources = "MCP.LoadResources";
         public const string McpExecuteTool = "MCP.ExecuteTool";
         public const string McpToolExecute = "MCP.Tool.Execute";
+
+        // Business hook activities
+        public const string BusinessExecute = "Business.Execute";
+        public const string BusinessBeforeExecutionHook = "Business.BeforeExecutionHook";
+        public const string BusinessAfterEachSceneHook = "Business.AfterEachSceneHook";
+        public const string BusinessOnTerminalSceneHook = "Business.OnTerminalSceneHook";
     }
 }

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/CostTrackingAfterSceneTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/CostTrackingAfterSceneTests.cs
@@ -35,7 +35,9 @@ public class CostTrackingAfterSceneTests
         AiResponseStatus.Completed,
         AiResponseStatus.Error,
         AiResponseStatus.BudgetExceeded,
-        AiResponseStatus.Unauthorized
+        AiResponseStatus.Unauthorized,
+        AiResponseStatus.Timeout,
+        AiResponseStatus.RateLimited
     ];
 
     /// <summary>
@@ -73,6 +75,47 @@ public class CostTrackingAfterSceneTests
                     Message = $"Cost summary: {scene.TotalCost:F4}"
                 };
                 return Task.FromResult(PlayFrameworkSceneResult.ForwardAndInject(scene, summary));
+            }
+
+            return Task.FromResult(PlayFrameworkSceneResult.Forward(scene));
+        }
+    }
+
+    /// <summary>
+    /// Calls <see cref="PlayFrameworkSceneResult.ForwardAndInject"/> with zero extra items
+    /// and tracks invocations in <c>context.Items["hookInvocations"]</c>.
+    /// </summary>
+    private sealed class InjectZeroExtrasHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("hookInvocations", _ => 0);
+            context.Items["hookInvocations"] = count + 1;
+            // ForwardAndInject with no extras: forwards the item, injects nothing.
+            return Task.FromResult(PlayFrameworkSceneResult.ForwardAndInject(scene));
+        }
+    }
+
+    /// <summary>
+    /// For <see cref="AiResponseStatus.Completed"/> items: calls
+    /// <see cref="PlayFrameworkSceneResult.ForwardAndInject"/> with exactly three extra items.
+    /// Tracks invocations in <c>context.Items["hookInvocations"]</c>.
+    /// </summary>
+    private sealed class InjectThreeExtrasHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("hookInvocations", _ => 0);
+            context.Items["hookInvocations"] = count + 1;
+
+            if (scene.Status == AiResponseStatus.Completed)
+            {
+                var e1 = new AiSceneResponse { Status = AiResponseStatus.FinalResponse, Message = "extra-1" };
+                var e2 = new AiSceneResponse { Status = AiResponseStatus.FinalResponse, Message = "extra-2" };
+                var e3 = new AiSceneResponse { Status = AiResponseStatus.FinalResponse, Message = "extra-3" };
+                return Task.FromResult(PlayFrameworkSceneResult.ForwardAndInject(scene, e1, e2, e3));
             }
 
             return Task.FromResult(PlayFrameworkSceneResult.Forward(scene));
@@ -176,5 +219,59 @@ public class CostTrackingAfterSceneTests
         Assert.True(invocations < results.Count,
             $"AfterEachScene hook ({invocations} calls) should be invoked fewer times than " +
             $"total results ({results.Count}) because injected items bypass the hook.");
+    }
+
+    /// <summary>
+    /// When <see cref="PlayFrameworkSceneResult.ForwardAndInject"/> is called with zero extra
+    /// items, the original item must still be forwarded and no extra items appear in the stream.
+    /// Hook invocation count must equal total result count (no items bypass the hook).
+    /// </summary>
+    [Fact]
+    public async Task ForwardAndInject_ZeroExtras_NoExtraItemsInResults()
+    {
+        var sp = BuildServices("ct-zero-extras", b =>
+            b.Business.AddAfterEachScene<InjectZeroExtrasHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ct-zero-extras", context);
+
+        Assert.NotEmpty(results);
+
+        // Every result item was seen by the hook: invocations == total count
+        // (ForwardAndInject with zero extras adds nothing extra, so count stays equal)
+        var invocations = context.Items.TryGetValue("hookInvocations", out var rawInv)
+            ? (int)rawInv!
+            : 0;
+        Assert.Equal(results.Count, invocations);
+    }
+
+    /// <summary>
+    /// When <see cref="PlayFrameworkSceneResult.ForwardAndInject"/> is called with three extra
+    /// items for each <see cref="AiResponseStatus.Completed"/> scene, the three extras must
+    /// appear in the stream and must bypass the hook (invocations &lt; total result count).
+    /// </summary>
+    [Fact]
+    public async Task ForwardAndInject_ThreeExtras_AllExtrasInResultsAndBypassHook()
+    {
+        var sp = BuildServices("ct-three-extras", b =>
+            b.Business.AddAfterEachScene<InjectThreeExtrasHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ct-three-extras", context);
+
+        // At least 3 FinalResponse items injected (one set of extras per Completed scene)
+        var extraItems = results
+            .Where(r => r.Scene?.Status == AiResponseStatus.FinalResponse)
+            .ToList();
+        Assert.True(extraItems.Count >= 3,
+            $"Expected at least 3 injected FinalResponse items, found {extraItems.Count}.");
+
+        // Extra items bypass the hook, so invocations < total result count
+        var invocations = context.Items.TryGetValue("hookInvocations", out var rawInv)
+            ? (int)rawInv!
+            : 0;
+        Assert.True(invocations < results.Count,
+            $"InjectThreeExtrasHook ({invocations} invocations) should be invoked fewer times " +
+            $"than total results ({results.Count}) because the 3 injected extras bypass it.");
     }
 }

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/CostTrackingAfterSceneTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/CostTrackingAfterSceneTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Test.Tests.BusinessHooks;
+
+/// <summary>
+/// Tests for <see cref="IPlayFrameworkAfterEachScene"/> hooks.
+/// Covers: cost accumulation via Forward, Suppress of non-terminal items, and ForwardAndInject.
+/// </summary>
+public class CostTrackingAfterSceneTests
+{
+    // ── Hooks ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Counts how many times the hook is invoked and accumulates <see cref="AiSceneResponse.TotalCost"/>
+    /// into <c>context.Items["sceneCount"]</c> / <c>context.Items["totalCost"]</c>.
+    /// </summary>
+    private sealed class CostAccumulatorHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("sceneCount", _ => 0);
+            context.Items["sceneCount"] = count + 1;
+
+            var cost = (decimal)context.Items.GetOrAdd("totalCost", _ => 0m);
+            context.Items["totalCost"] = cost + scene.TotalCost;
+
+            return Task.FromResult(PlayFrameworkSceneResult.Forward(scene));
+        }
+    }
+
+    private static readonly HashSet<AiResponseStatus> TerminalStatuses =
+    [
+        AiResponseStatus.Completed,
+        AiResponseStatus.Error,
+        AiResponseStatus.BudgetExceeded,
+        AiResponseStatus.Unauthorized
+    ];
+
+    /// <summary>
+    /// Suppresses all non-terminal scene items; lets terminal items through unchanged.
+    /// </summary>
+    private sealed class SuppressNonTerminalHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            return Task.FromResult(TerminalStatuses.Contains(scene.Status)
+                ? PlayFrameworkSceneResult.Forward(scene)
+                : PlayFrameworkSceneResult.Suppress());
+        }
+    }
+
+    /// <summary>
+    /// For <see cref="AiResponseStatus.Completed"/> scenes: forwards the original and injects a
+    /// synthetic cost-summary item via <see cref="PlayFrameworkSceneResult.ForwardAndInject"/>.
+    /// Tracks total hook invocations in <c>context.Items["hookInvocations"]</c>.
+    /// </summary>
+    private sealed class InjectCostSummaryHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("hookInvocations", _ => 0);
+            context.Items["hookInvocations"] = count + 1;
+
+            if (scene.Status == AiResponseStatus.Completed)
+            {
+                var summary = new AiSceneResponse
+                {
+                    Status = AiResponseStatus.FinalResponse,
+                    Message = $"Cost summary: {scene.TotalCost:F4}"
+                };
+                return Task.FromResult(PlayFrameworkSceneResult.ForwardAndInject(scene, summary));
+            }
+
+            return Task.FromResult(PlayFrameworkSceneResult.Forward(scene));
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IServiceProvider BuildServices(string name, Action<PlayFrameworkBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new MockChatClient());
+        services.AddPlayFramework(name, builder =>
+        {
+            builder
+                .WithExecutionMode(SceneExecutionMode.Direct)
+                .AddScene("Stub", "Stub scene for hook tests", _ => { });
+            configure(builder);
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>> RunAsync(
+        IServiceProvider sp, string name, PlayFrameworkExecutionContext context)
+    {
+        using var scope = sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IFactory<IPlayFrameworkBusinessManager>>();
+        var manager = factory.Create(name)!;
+        var results = new List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>();
+        await foreach (var item in manager.ExecuteAsync(name, context))
+            results.Add(item);
+        return results;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An after-each-scene hook using Forward must be invoked once per scene item,
+    /// with the invocation count matching the final result count.
+    /// </summary>
+    [Fact]
+    public async Task AfterEachScene_Forward_HookCalledForEveryItem()
+    {
+        var sp = BuildServices("ct-forward", b =>
+            b.Business.AddAfterEachScene<CostAccumulatorHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ct-forward", context);
+
+        Assert.NotEmpty(results);
+        Assert.True(context.Items.TryGetValue("sceneCount", out var rawCount));
+        // Hook is called exactly once per result (no extras in this test)
+        Assert.Equal(results.Count, (int)rawCount!);
+    }
+
+    /// <summary>
+    /// A hook that suppresses non-terminal items must leave only terminal items in the stream.
+    /// </summary>
+    [Fact]
+    public async Task AfterEachScene_SuppressNonTerminal_OnlyTerminalItemsInResults()
+    {
+        var sp = BuildServices("ct-suppress", b =>
+            b.Business.AddAfterEachScene<SuppressNonTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ct-suppress", context);
+
+        // All surviving items must have a terminal status
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r.Scene);
+            Assert.Contains(r.Scene!.Status, TerminalStatuses);
+        });
+    }
+
+    /// <summary>
+    /// A hook that uses ForwardAndInject must append extra items to the stream,
+    /// and those injected items must bypass the hook (i.e. hook invocation count
+    /// is strictly less than total result count).
+    /// </summary>
+    [Fact]
+    public async Task AfterEachScene_ForwardAndInject_ExtraItemsBypassHook()
+    {
+        var sp = BuildServices("ct-inject", b =>
+            b.Business.AddAfterEachScene<InjectCostSummaryHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ct-inject", context);
+
+        // At least one synthetic cost-summary item must have been injected
+        var summaries = results
+            .Where(r => r.Scene?.Status == AiResponseStatus.FinalResponse)
+            .ToList();
+        Assert.NotEmpty(summaries);
+
+        // Injected items bypass the hook, so invocations < total result count
+        var invocations = context.Items.TryGetValue("hookInvocations", out var rawInv)
+            ? (int)rawInv!
+            : 0;
+        Assert.True(invocations < results.Count,
+            $"AfterEachScene hook ({invocations} calls) should be invoked fewer times than " +
+            $"total results ({results.Count}) because injected items bypass the hook.");
+    }
+}

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/RateLimitBeforeExecutionTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/RateLimitBeforeExecutionTests.cs
@@ -1,0 +1,186 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Test.Tests.BusinessHooks;
+
+/// <summary>
+/// Tests for <see cref="IPlayFrameworkBeforeExecution"/> hooks.
+/// Covers: Deny (rate-limit), Allow (pass-through), ShortCircuit, and priority ordering.
+/// </summary>
+public class RateLimitBeforeExecutionTests
+{
+    // ── Hooks ─────────────────────────────────────────────────────────────────
+
+    private sealed class DenyHook : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            context.Items["hookCalled"] = true;
+            return Task.FromResult(PlayFrameworkGuardResult.Deny(429, "Too many requests"));
+        }
+    }
+
+    private sealed class AllowHook : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            context.Items["hookCalled"] = true;
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
+    private sealed class ShortCircuitHook : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var synthetic = new AiSceneResponse
+            {
+                Status = AiResponseStatus.Completed,
+                Message = "Short-circuited"
+            };
+            return Task.FromResult(PlayFrameworkGuardResult.ShortCircuit(synthetic));
+        }
+    }
+
+    // Two hooks that append a tag to context.Items["order"] so we can observe execution order.
+    private sealed class OrderHookLow : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("order", out var raw) && raw is List<string> list)
+                list.Add("low");
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
+    private sealed class OrderHookHigh : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("order", out var raw) && raw is List<string> list)
+                list.Add("high");
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IServiceProvider BuildServices(string name, Action<PlayFrameworkBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new MockChatClient());
+        services.AddPlayFramework(name, builder =>
+        {
+            builder
+                .WithExecutionMode(SceneExecutionMode.Direct)
+                .AddScene("Stub", "Stub scene for hook tests", _ => { });
+            configure(builder);
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>> RunAsync(
+        IServiceProvider sp, string name, PlayFrameworkExecutionContext context)
+    {
+        using var scope = sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IFactory<IPlayFrameworkBusinessManager>>();
+        var manager = factory.Create(name)!;
+        var results = new List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>();
+        await foreach (var item in manager.ExecuteAsync(name, context))
+            results.Add(item);
+        return results;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A deny hook must produce exactly one (null, DenyResult) tuple and stop the stream —
+    /// the scene manager must never be reached.
+    /// </summary>
+    [Fact]
+    public async Task DenyHook_Returns429_YieldsSingleDenyAndStops()
+    {
+        var sp = BuildServices("rl-deny", b => b.Business.AddBeforeExecution<DenyHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-deny", context);
+
+        Assert.Single(results);
+        Assert.Null(results[0].Scene);
+        Assert.NotNull(results[0].Deny);
+        Assert.Equal(429, results[0].Deny!.StatusCode);
+        Assert.Equal("Too many requests", results[0].Deny!.ErrorDetail);
+        Assert.True((bool)context.Items["hookCalled"]);
+    }
+
+    /// <summary>
+    /// An allow hook must let execution proceed to the scene manager, yielding at least one scene result
+    /// with no deny payloads.
+    /// </summary>
+    [Fact]
+    public async Task AllowHook_ProceedsToSceneManager_YieldsSceneResults()
+    {
+        var sp = BuildServices("rl-allow", b => b.Business.AddBeforeExecution<AllowHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-allow", context);
+
+        Assert.True((bool)context.Items["hookCalled"]);
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.Null(r.Deny));
+    }
+
+    /// <summary>
+    /// A short-circuit hook must yield exactly the synthetic response it returns and stop
+    /// the stream — the scene manager must never be reached.
+    /// </summary>
+    [Fact]
+    public async Task ShortCircuitHook_YieldsSyntheticResponseAndStops()
+    {
+        var sp = BuildServices("rl-sc", b => b.Business.AddBeforeExecution<ShortCircuitHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-sc", context);
+
+        Assert.Single(results);
+        Assert.Null(results[0].Deny);
+        Assert.NotNull(results[0].Scene);
+        Assert.Equal("Short-circuited", results[0].Scene!.Message);
+        Assert.Equal(AiResponseStatus.Completed, results[0].Scene!.Status);
+    }
+
+    /// <summary>
+    /// When two before-execution hooks are registered, they must run in ascending priority order
+    /// regardless of their registration order.
+    /// </summary>
+    [Fact]
+    public async Task Priority_LowerNumberRunsBeforeHigherNumber()
+    {
+        // OrderHookHigh registered first at priority=10, OrderHookLow registered second at priority=1.
+        // Expected execution: "low" (priority=1) before "high" (priority=10).
+        var sp = BuildServices("rl-pri", b =>
+            b.Business
+                .AddBeforeExecution<OrderHookHigh>(priority: 10)
+                .AddBeforeExecution<OrderHookLow>(priority: 1));
+
+        var order = new List<string>();
+        var context = new PlayFrameworkExecutionContext
+        {
+            Message = "hello",
+            Items = new ConcurrentDictionary<string, object> { ["order"] = order }
+        };
+
+        await RunAsync(sp, "rl-pri", context);
+
+        Assert.Equal(2, order.Count);
+        Assert.Equal("low", order[0]);   // priority=1 ran first
+        Assert.Equal("high", order[1]);  // priority=10 ran second
+    }
+}

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/RateLimitBeforeExecutionTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/RateLimitBeforeExecutionTests.cs
@@ -69,6 +69,53 @@ public class RateLimitBeforeExecutionTests
         }
     }
 
+    /// <summary>Returns Allow and increments <c>context.Items["allowCount"]</c>.</summary>
+    private sealed class CountingAllowHook : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("allowCount", _ => 0);
+            context.Items["allowCount"] = count + 1;
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
+    /// <summary>Denies with a non-string <see cref="object?"/> payload.</summary>
+    private sealed class DenyObjectHook : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var payload = new { Reason = "TooMany", RetryAfterSeconds = 60 };
+            return Task.FromResult(PlayFrameworkGuardResult.Deny(429, payload));
+        }
+    }
+
+    /// <summary>Appends "first" to <c>context.Items["order"]</c> and returns Allow.</summary>
+    private sealed class OrderHookFirst : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("order", out var raw) && raw is List<string> list)
+                list.Add("first");
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
+    /// <summary>Appends "second" to <c>context.Items["order"]</c> and returns Allow.</summary>
+    private sealed class OrderHookSecond : IPlayFrameworkBeforeExecution
+    {
+        public Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
+            PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("order", out var raw) && raw is List<string> list)
+                list.Add("second");
+            return Task.FromResult(PlayFrameworkGuardResult.Allow());
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static IServiceProvider BuildServices(string name, Action<PlayFrameworkBuilder> configure)
@@ -182,5 +229,121 @@ public class RateLimitBeforeExecutionTests
         Assert.Equal(2, order.Count);
         Assert.Equal("low", order[0]);   // priority=1 ran first
         Assert.Equal("high", order[1]);  // priority=10 ran second
+    }
+
+    /// <summary>
+    /// When the first hook in priority order returns Deny, subsequent hooks must not execute.
+    /// </summary>
+    [Fact]
+    public async Task MultiHook_FirstDeny_SubsequentHookDoesNotRun()
+    {
+        // DenyHook at priority=1 runs first and denies; CountingAllowHook at priority=2 must not run.
+        var sp = BuildServices("rl-multi-deny", b =>
+            b.Business
+                .AddBeforeExecution<DenyHook>(priority: 1)
+                .AddBeforeExecution<CountingAllowHook>(priority: 2));
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-multi-deny", context);
+
+        Assert.Single(results);
+        Assert.NotNull(results[0].Deny);
+        var allowCount = context.Items.TryGetValue("allowCount", out var raw) ? (int)raw! : 0;
+        Assert.Equal(0, allowCount);
+    }
+
+    /// <summary>
+    /// When the first hook allows and the second denies, execution stops at the deny
+    /// and the first hook's side-effect is visible.
+    /// </summary>
+    [Fact]
+    public async Task MultiHook_FirstAllow_SecondDeny_StopsAtSecond()
+    {
+        // CountingAllowHook at priority=1 allows; DenyHook at priority=2 denies.
+        var sp = BuildServices("rl-allow-deny", b =>
+            b.Business
+                .AddBeforeExecution<CountingAllowHook>(priority: 1)
+                .AddBeforeExecution<DenyHook>(priority: 2));
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-allow-deny", context);
+
+        Assert.Single(results);
+        Assert.NotNull(results[0].Deny);
+        // CountingAllowHook must have run before the Deny
+        var allowCount = context.Items.TryGetValue("allowCount", out var raw) ? (int)raw! : 0;
+        Assert.Equal(1, allowCount);
+    }
+
+    /// <summary>
+    /// A Deny hook can pass any object as the error detail, not just a string.
+    /// The DenyResult.ErrorDetail must be non-null and preserve the object reference.
+    /// </summary>
+    [Fact]
+    public async Task Deny_WithObjectPayload_ErrorDetailIsObjectNotNull()
+    {
+        var sp = BuildServices("rl-obj-deny", b => b.Business.AddBeforeExecution<DenyObjectHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "rl-obj-deny", context);
+
+        Assert.Single(results);
+        Assert.NotNull(results[0].Deny);
+        Assert.Equal(429, results[0].Deny!.StatusCode);
+        // ErrorDetail must be the anonymous object, not null and not a plain string
+        Assert.NotNull(results[0].Deny!.ErrorDetail);
+        Assert.IsNotType<string>(results[0].Deny!.ErrorDetail);
+    }
+
+    /// <summary>
+    /// Two hooks with equal priority must run in registration order (stable sort).
+    /// </summary>
+    [Fact]
+    public async Task EqualPriority_RegistrationOrderPreserved()
+    {
+        // Both registered at default priority=0; OrderHookFirst registered before OrderHookSecond.
+        var sp = BuildServices("rl-equal-pri", b =>
+            b.Business
+                .AddBeforeExecution<OrderHookFirst>(priority: 0)
+                .AddBeforeExecution<OrderHookSecond>(priority: 0));
+
+        var order = new List<string>();
+        var context = new PlayFrameworkExecutionContext
+        {
+            Message = "hello",
+            Items = new System.Collections.Concurrent.ConcurrentDictionary<string, object> { ["order"] = order }
+        };
+
+        await RunAsync(sp, "rl-equal-pri", context);
+
+        Assert.Equal(2, order.Count);
+        Assert.Equal("first", order[0]);
+        Assert.Equal("second", order[1]);
+    }
+
+    /// <summary>
+    /// Registering the same hook type twice must not throw during setup or execution.
+    /// All registrations are kept; execution should succeed and reach the scene manager.
+    /// </summary>
+    [Fact]
+    public async Task DuplicateTypeRegistration_NoException_ExecutionSucceeds()
+    {
+        // Register AllowHook twice — must not throw ArgumentException.
+        IServiceProvider sp = null!;
+        var ex = Record.Exception(() =>
+        {
+            sp = BuildServices("rl-dup", b =>
+                b.Business
+                    .AddBeforeExecution<AllowHook>()
+                    .AddBeforeExecution<AllowHook>());
+        });
+        Assert.Null(ex);
+
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+        var results = await RunAsync(sp, "rl-dup", context);
+
+        // Execution must reach the scene manager and return at least one scene result.
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.Null(r.Deny));
     }
 }

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/TerminalSceneLogTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/TerminalSceneLogTests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Test.Tests.BusinessHooks;
+
+/// <summary>
+/// Tests for <see cref="IPlayFrameworkOnTerminalScene"/> hooks.
+/// Covers: hook fires on terminal status, fires even when the terminal item was suppressed,
+/// and injected items bypass after-each-scene hooks.
+/// </summary>
+public class TerminalSceneLogTests
+{
+    private static readonly HashSet<AiResponseStatus> TerminalStatuses =
+    [
+        AiResponseStatus.Completed,
+        AiResponseStatus.Error,
+        AiResponseStatus.BudgetExceeded,
+        AiResponseStatus.Unauthorized
+    ];
+
+    // ── Hooks ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// On terminal: records the triggering status in <c>context.Items["terminalStatus"]</c>
+    /// and injects a synthetic log item.
+    /// </summary>
+    private sealed class LogTerminalHook : IPlayFrameworkOnTerminalScene
+    {
+        public Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+            AiSceneResponse terminalScene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            context.Items["terminalStatus"] = terminalScene.Status;
+            var logItem = new AiSceneResponse
+            {
+                Status = AiResponseStatus.FinalResponse,
+                Message = $"Log: terminal={terminalScene.Status}"
+            };
+            return Task.FromResult<IEnumerable<AiSceneResponse>?>([logItem]);
+        }
+    }
+
+    /// <summary>Suppresses every item unconditionally (including terminal ones).</summary>
+    private sealed class SuppressAllHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+            => Task.FromResult(PlayFrameworkSceneResult.Suppress());
+    }
+
+    /// <summary>
+    /// Forwards all items and increments <c>context.Items["afterCount"]</c> on each call.
+    /// Used to verify that terminal-injected items bypass after-hooks.
+    /// </summary>
+    private sealed class CountingAfterHook : IPlayFrameworkAfterEachScene
+    {
+        public Task<PlayFrameworkSceneResult> AfterSceneAsync(
+            AiSceneResponse scene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            var count = (int)context.Items.GetOrAdd("afterCount", _ => 0);
+            context.Items["afterCount"] = count + 1;
+            return Task.FromResult(PlayFrameworkSceneResult.Forward(scene));
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IServiceProvider BuildServices(string name, Action<PlayFrameworkBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new MockChatClient());
+        services.AddPlayFramework(name, builder =>
+        {
+            builder
+                .WithExecutionMode(SceneExecutionMode.Direct)
+                .AddScene("Stub", "Stub scene for hook tests", _ => { });
+            configure(builder);
+        });
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task<List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>> RunAsync(
+        IServiceProvider sp, string name, PlayFrameworkExecutionContext context)
+    {
+        using var scope = sp.CreateScope();
+        var factory = scope.ServiceProvider.GetRequiredService<IFactory<IPlayFrameworkBusinessManager>>();
+        var manager = factory.Create(name)!;
+        var results = new List<(AiSceneResponse? Scene, PlayFrameworkDenyResult? Deny)>();
+        await foreach (var item in manager.ExecuteAsync(name, context))
+            results.Add(item);
+        return results;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The OnTerminalScene hook must fire when the stream reaches a terminal status,
+    /// record the triggering status, and append its injected log item to the stream.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_CompletedStatus_HookFiresAndInjectsLogItem()
+    {
+        var sp = BuildServices("ts-fire", b =>
+            b.Business.AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ts-fire", context);
+
+        // Hook must have fired and recorded the terminal status
+        Assert.True(context.Items.TryGetValue("terminalStatus", out var rawStatus),
+            "OnTerminalScene hook should have written terminalStatus to context.Items");
+        var status = (AiResponseStatus)rawStatus!;
+        Assert.Contains(status, TerminalStatuses);
+
+        // The injected log item must appear in results
+        var logItems = results
+            .Where(r => r.Scene?.Status == AiResponseStatus.FinalResponse)
+            .ToList();
+        Assert.NotEmpty(logItems);
+        Assert.Contains(logItems, r => r.Scene!.Message!.StartsWith("Log: terminal="));
+    }
+
+    /// <summary>
+    /// When an after-each-scene hook suppresses the terminal item, the OnTerminalScene hook
+    /// must still fire (trigger is the raw status, not whether the item was sent to the client).
+    /// Items injected by the terminal hook must still appear in the stream.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_FiresEvenWhenTerminalItemIsSuppressed()
+    {
+        var sp = BuildServices("ts-suppress", b =>
+            b.Business
+                .AddAfterEachScene<SuppressAllHook>()
+                .AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ts-suppress", context);
+
+        // Terminal hook must still have fired despite suppression
+        Assert.True(context.Items.ContainsKey("terminalStatus"),
+            "OnTerminalScene hook must fire even when the terminal item is suppressed by AfterEachScene.");
+
+        // Injected items from the terminal hook must appear in results
+        var logItems = results
+            .Where(r => r.Scene?.Status == AiResponseStatus.FinalResponse)
+            .ToList();
+        Assert.NotEmpty(logItems);
+    }
+
+    /// <summary>
+    /// Items injected by OnTerminalScene must bypass after-each-scene hooks.
+    /// The CountingAfterHook invocation count must be less than the total result count
+    /// because the injected log item is never passed through it.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_InjectedItems_BypassAfterEachSceneHooks()
+    {
+        var sp = BuildServices("ts-bypass", b =>
+            b.Business
+                .AddAfterEachScene<CountingAfterHook>()
+                .AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        var results = await RunAsync(sp, "ts-bypass", context);
+
+        Assert.NotEmpty(results);
+
+        var afterCount = context.Items.TryGetValue("afterCount", out var rawCount)
+            ? (int)rawCount!
+            : 0;
+
+        // Total results include at least one log item from the terminal hook.
+        // That log item bypasses CountingAfterHook, so afterCount < results.Count.
+        Assert.True(afterCount < results.Count,
+            $"AfterEachScene hook ({afterCount} invocations) should not be called for " +
+            $"terminal-injected items (total results={results.Count}).");
+    }
+}

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/TerminalSceneLogTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/BusinessHooks/TerminalSceneLogTests.cs
@@ -6,7 +6,7 @@ namespace Rystem.PlayFramework.Test.Tests.BusinessHooks;
 /// <summary>
 /// Tests for <see cref="IPlayFrameworkOnTerminalScene"/> hooks.
 /// Covers: hook fires on terminal status, fires even when the terminal item was suppressed,
-/// and injected items bypass after-each-scene hooks.
+/// injected items bypass after-each-scene hooks, and priority ordering.
 /// </summary>
 public class TerminalSceneLogTests
 {
@@ -15,7 +15,9 @@ public class TerminalSceneLogTests
         AiResponseStatus.Completed,
         AiResponseStatus.Error,
         AiResponseStatus.BudgetExceeded,
-        AiResponseStatus.Unauthorized
+        AiResponseStatus.Unauthorized,
+        AiResponseStatus.Timeout,
+        AiResponseStatus.RateLimited
     ];
 
     // ── Hooks ─────────────────────────────────────────────────────────────────
@@ -62,6 +64,67 @@ public class TerminalSceneLogTests
         }
     }
 
+    /// <summary>Runs at priority=1; appends "low" to <c>context.Items["terminalOrder"]</c>.</summary>
+    private sealed class LogTerminalHookLow : IPlayFrameworkOnTerminalScene
+    {
+        public Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+            AiSceneResponse terminalScene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("terminalOrder", out var raw) && raw is List<string> list)
+                list.Add("low");
+            return Task.FromResult<IEnumerable<AiSceneResponse>?>(null);
+        }
+    }
+
+    /// <summary>Runs at priority=10; appends "high" to <c>context.Items["terminalOrder"]</c>.</summary>
+    private sealed class LogTerminalHookHigh : IPlayFrameworkOnTerminalScene
+    {
+        public Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
+            AiSceneResponse terminalScene, PlayFrameworkExecutionContext context, CancellationToken ct = default)
+        {
+            if (context.Items.TryGetValue("terminalOrder", out var raw) && raw is List<string> list)
+                list.Add("high");
+            return Task.FromResult<IEnumerable<AiSceneResponse>?>(null);
+        }
+    }
+
+    /// <summary>
+    /// Stub <see cref="ISceneManager"/> that yields a fixed sequence of responses without
+    /// calling an LLM. Used to inject specific terminal statuses in tests.
+    /// </summary>
+    private sealed class StubSceneManager : ISceneManager
+    {
+        private readonly AiSceneResponse[] _responses;
+
+        public StubSceneManager(params AiSceneResponse[] responses) => _responses = responses;
+
+        public async IAsyncEnumerable<AiSceneResponse> ExecuteAsync(
+            MultiModalInput input,
+            Dictionary<string, object>? metadata = null,
+            SceneRequestSettings? settings = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var r in _responses)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return r;
+            }
+        }
+
+        public async IAsyncEnumerable<AiSceneResponse> ExecuteAsync(
+            string message,
+            Dictionary<string, object>? metadata = null,
+            SceneRequestSettings? settings = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var r in _responses)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return r;
+            }
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static IServiceProvider BuildServices(string name, Action<PlayFrameworkBuilder> configure)
@@ -76,6 +139,30 @@ public class TerminalSceneLogTests
                 .AddScene("Stub", "Stub scene for hook tests", _ => { });
             configure(builder);
         });
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Builds a service provider where the scene manager is replaced by a
+    /// <see cref="StubSceneManager"/> that emits a single response with
+    /// <paramref name="terminalStatus"/> as its status.
+    /// </summary>
+    private static IServiceProvider BuildServicesWithStub(
+        string name, AiResponseStatus terminalStatus, Action<PlayFrameworkBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new MockChatClient());
+        services.AddPlayFramework(name, builder =>
+        {
+            builder
+                .WithExecutionMode(SceneExecutionMode.Direct)
+                .AddScene("Stub", "Stub scene for hook tests", _ => { });
+            configure(builder);
+        });
+        // Replace the real SceneManager with a stub that emits exactly one terminal response.
+        var stub = new StubSceneManager(new AiSceneResponse { Status = terminalStatus });
+        services.AddOrOverrideFactory<ISceneManager, StubSceneManager>(stub, name, ServiceLifetime.Singleton);
         return services.BuildServiceProvider();
     }
 
@@ -174,5 +261,101 @@ public class TerminalSceneLogTests
         Assert.True(afterCount < results.Count,
             $"AfterEachScene hook ({afterCount} invocations) should not be called for " +
             $"terminal-injected items (total results={results.Count}).");
+    }
+
+    /// <summary>
+    /// The OnTerminalScene hook must fire when the stream reaches an
+    /// <see cref="AiResponseStatus.Error"/> terminal status.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_ErrorStatus_HookFires()
+    {
+        var sp = BuildServicesWithStub("ts-error", AiResponseStatus.Error,
+            b => b.Business.AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        await RunAsync(sp, "ts-error", context);
+
+        Assert.True(context.Items.TryGetValue("terminalStatus", out var rawStatus));
+        Assert.Equal(AiResponseStatus.Error, (AiResponseStatus)rawStatus!);
+    }
+
+    /// <summary>
+    /// The OnTerminalScene hook must fire when the stream reaches a
+    /// <see cref="AiResponseStatus.BudgetExceeded"/> terminal status.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_BudgetExceededStatus_HookFires()
+    {
+        var sp = BuildServicesWithStub("ts-budget", AiResponseStatus.BudgetExceeded,
+            b => b.Business.AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        await RunAsync(sp, "ts-budget", context);
+
+        Assert.True(context.Items.TryGetValue("terminalStatus", out var rawStatus));
+        Assert.Equal(AiResponseStatus.BudgetExceeded, (AiResponseStatus)rawStatus!);
+    }
+
+    /// <summary>
+    /// The OnTerminalScene hook must fire when the stream reaches an
+    /// <see cref="AiResponseStatus.Unauthorized"/> terminal status.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_UnauthorizedStatus_HookFires()
+    {
+        var sp = BuildServicesWithStub("ts-unauth", AiResponseStatus.Unauthorized,
+            b => b.Business.AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        await RunAsync(sp, "ts-unauth", context);
+
+        Assert.True(context.Items.TryGetValue("terminalStatus", out var rawStatus));
+        Assert.Equal(AiResponseStatus.Unauthorized, (AiResponseStatus)rawStatus!);
+    }
+
+    /// <summary>
+    /// When multiple OnTerminalScene hooks are registered, they must run in ascending priority
+    /// order regardless of their registration order.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_MultipleHooks_PriorityOrderRespected()
+    {
+        // LogTerminalHookHigh registered first at priority=10, LogTerminalHookLow registered second at priority=1.
+        // Expected execution order: "low" (priority=1) then "high" (priority=10).
+        var sp = BuildServicesWithStub("ts-pri", AiResponseStatus.Completed, b =>
+            b.Business
+                .AddOnTerminalScene<LogTerminalHookHigh>(priority: 10)
+                .AddOnTerminalScene<LogTerminalHookLow>(priority: 1));
+
+        var order = new List<string>();
+        var context = new PlayFrameworkExecutionContext
+        {
+            Message = "hello",
+            Items = new System.Collections.Concurrent.ConcurrentDictionary<string, object> { ["terminalOrder"] = order }
+        };
+
+        await RunAsync(sp, "ts-pri", context);
+
+        Assert.Equal(2, order.Count);
+        Assert.Equal("low", order[0]);
+        Assert.Equal("high", order[1]);
+    }
+
+    /// <summary>
+    /// The OnTerminalScene hook must fire when the stream reaches a
+    /// <see cref="AiResponseStatus.Timeout"/> terminal status.
+    /// </summary>
+    [Fact]
+    public async Task OnTerminal_TimeoutStatus_HookFires()
+    {
+        var sp = BuildServicesWithStub("ts-timeout", AiResponseStatus.Timeout,
+            b => b.Business.AddOnTerminalScene<LogTerminalHook>());
+        var context = new PlayFrameworkExecutionContext { Message = "hello" };
+
+        await RunAsync(sp, "ts-timeout", context);
+
+        Assert.True(context.Items.TryGetValue("terminalStatus", out var rawStatus));
+        Assert.Equal(AiResponseStatus.Timeout, (AiResponseStatus)rawStatus!);
     }
 }


### PR DESCRIPTION
# Business Hooks for `Rystem.PlayFramework`

This PR introduces the **Business Hooks system** — a first-class pipeline extension mechanism that lets you inject cross-cutting logic into PlayFramework execution without modifying your scenes.

Before this change, the only places to intercept execution were inside scenes themselves or at the HTTP middleware level. There was no structured way to, for example:

- deny a request before the SSE stream opened
- track costs after every LLM response
- fire a cleanup job when execution terminated

without coupling that logic directly to scene code.

---

# What changed

Three new hook interfaces were introduced, each targeting a distinct phase of the execution lifecycle:

| Interface | Phase | Runs |
|---|---|---|
| `IPlayFrameworkBeforeExecution` | Before the SSE stream opens | Once per request |
| `IPlayFrameworkAfterEachScene` | After each `AiSceneResponse` is produced | For every item emitted |
| `IPlayFrameworkOnTerminalScene` | When a terminal status is detected | Once, at the end |

All hooks are resolved from DI as scoped services (one instance per HTTP request) and share a `PlayFrameworkExecutionContext` — including a thread-safe `Items` bag that can be used to pass data between hooks without touching the domain model.

---

# Registration

Hooks are registered on `framework.Business` inside `AddPlayFramework`:

```csharp
builder.Services.AddPlayFramework("default", framework =>
{
    framework
        .WithChatClient("default")
        .AddScene("Assistant", "General conversation", _ => { });

    framework.Business
        .AddBeforeExecution<RateLimitHook>(priority: 0)
        .AddBeforeExecution<AuditLogHook>(priority: 10)
        .AddAfterEachScene<CostAccumulatorHook>(priority: 0)
        .AddOnTerminalScene<SessionFinalizerHook>(priority: 0);
});
```

The `priority` parameter controls execution order within each hook type — lower numbers run first.

Multiple hooks of the same type are fully supported.

---

# Example: gate requests before the stream opens

`IPlayFrameworkBeforeExecution` returns one of three outcomes:

```csharp
public sealed class RateLimitHook : IPlayFrameworkBeforeExecution
{
    private readonly IRateLimitService _rateLimiter;

    public RateLimitHook(IRateLimitService rateLimiter)
        => _rateLimiter = rateLimiter;

    public async Task<PlayFrameworkGuardResult> BeforeExecutionAsync(
        PlayFrameworkExecutionContext context,
        CancellationToken cancellationToken = default)
    {
        var userId = context.User?.FindFirst("sub")?.Value ?? "anonymous";

        var allowed = await _rateLimiter.TryAcquireAsync(userId, cancellationToken);

        if (!allowed)
        {
            return PlayFrameworkGuardResult.Deny(
                429,
                "Rate limit exceeded. Try again later.");
        }

        context.Items["userId"] = userId;

        return PlayFrameworkGuardResult.Allow();
    }
}
```

| Outcome | Effect |
|---|---|
| `Allow()` | Proceeds to the next hook or starts the stream |
| `Deny(statusCode, detail)` | Returns the given HTTP error; stream never opens |
| `ShortCircuit(response)` | Emits one synthetic SSE item then closes; `ISceneManager` is never called |

`errorDetail` on `Deny` accepts `object?` (not just a string), so structured error bodies can be returned directly.

---

# Example: observe or modify every response item

`IPlayFrameworkAfterEachScene` intercepts every `AiSceneResponse` before it reaches the client:

```csharp
public sealed class CostAccumulatorHook : IPlayFrameworkAfterEachScene
{
    private readonly ICostRepository _repo;

    public CostAccumulatorHook(ICostRepository repo)
        => _repo = repo;

    public async Task<PlayFrameworkSceneResult> AfterSceneAsync(
        AiSceneResponse scene,
        PlayFrameworkExecutionContext context,
        CancellationToken cancellationToken = default)
    {
        if (scene.Cost is not null)
        {
            var userId = (string)context.Items["userId"];

            await _repo.AccumulateAsync(
                userId,
                scene.Cost.Value,
                cancellationToken);
        }

        return PlayFrameworkSceneResult.Forward(scene);
    }
}
```

| Outcome | Effect |
|---|---|
| `Forward(scene)` | Sends the (optionally modified) item to the client |
| `Suppress()` | Discards the item; client never sees it |
| `ForwardAndInject(scene, extras)` | Sends the item, then appends extra synthetic items (`extras` bypass `AfterEachScene` hooks) |

---

# Example: react when execution terminates

`IPlayFrameworkOnTerminalScene` fires exactly once when one of the following statuses is detected:

- `Completed`
- `Error`
- `BudgetExceeded`
- `Unauthorized`
- `Timeout`
- `RateLimited`

The terminal item is always sent to the client first; anything this hook returns is appended afterwards and bypasses `IPlayFrameworkAfterEachScene`.

```csharp
public sealed class SessionFinalizerHook : IPlayFrameworkOnTerminalScene
{
    private readonly ISessionRepository _sessions;

    public SessionFinalizerHook(ISessionRepository sessions)
        => _sessions = sessions;

    public async Task<IEnumerable<AiSceneResponse>?> OnTerminalAsync(
        AiSceneResponse terminalScene,
        PlayFrameworkExecutionContext context,
        CancellationToken cancellationToken = default)
    {
        var userId = (string)context.Items["userId"];

        var summary = await _sessions.FinalizeAsync(
            userId,
            terminalScene.Status,
            cancellationToken);

        return
        [
            new AiSceneResponse
            {
                Status = AiResponseStatus.FinalResponse,
                Message = $"Session finalized. Total cost: {summary.TotalCost:F4} USD."
            }
        ];
    }
}
```

---

# Request timeout

A per-request SSE timeout is now configurable:

```csharp
builder.Services.Configure<PlayFrameworkApiSettings>(options =>
{
    options.TimeoutInSeconds = 30;
});
```

When the timeout fires:

- If the SSE stream has **not yet started**: the endpoint returns HTTP 504 and the connection is closed.
- If the SSE stream **is already open**: a synthetic `AiResponseStatus.Timeout` item is emitted into the stream before the connection closes, so clients can detect and handle the timeout gracefully.

---

# Test coverage

22 unit tests across three files:

- `RateLimitBeforeExecutionTests.cs`
  - deny / allow / short-circuit paths
  - priority ordering and equal-priority registration order
  - `Items` sharing between hooks
  - first-Deny stops the chain; first-Allow + second-Deny stops at second
  - `Deny` with structured `object?` payload
  - duplicate type registration raises no exception

- `CostTrackingAfterSceneTests.cs`
  - forward / suppress / inject semantics
  - `ForwardAndInject` with zero extras: invocations equal total count
  - `ForwardAndInject` with three extras: extra items in stream and bypass hook

- `TerminalSceneLogTests.cs`
  - terminal hook fires for `Completed`, `Error`, `BudgetExceeded`, `Unauthorized`, `Timeout`
  - multiple `OnTerminalScene` hooks respect priority order
  - terminal item always emitted before hook-injected items

---

# Important behavior notes

- Hooks are scoped — one instance per HTTP request, safe to inject `IHttpContextAccessor` and other scoped services.
- `ForwardAndInject` extras and `OnTerminalScene` injected items bypass `IPlayFrameworkAfterEachScene` to prevent infinite loops.
- `OnTerminalScene` fires based on the original response status, even if the triggering item was suppressed by an `AfterEachScene` hook.
- A `BeforeExecution` hook can mutate `context.Settings` (for example inject `ForcedTools` or lower `MaxBudget`) before execution begins.
- `IPlayFrameworkBusinessManager` is always registered, even when no hooks are configured — it handles the timeout and delegates to `ISceneManager` transparently.
- If a hook throws a non-cancellation exception it is wrapped in `PlayFrameworkHookException` (which carries `HookTypeName`, `Phase`, and `Priority`) and propagated — the pipeline does not silently swallow hook errors.
- If the same hook implementation type is registered more than once, a `LogWarning` is emitted **once per `IPlayFrameworkBusinessManager` instance** at the first `ExecuteAsync` call, reporting the type name, registration count, factory name, and all registered priorities. All duplicate registrations are kept; no registration is silently dropped.
- Business hook spans are automatically emitted via `PlayFrameworkActivitySource`. Each hook invocation creates a child `Activity` tagged with `hook.type` and `hook.outcome`. `Deny`, `ShortCircuit`, and `Suppress` outcomes also record a named `ActivityEvent`.
