### PR TITLE
fix: serialization in http tool builder

### DIFF
--- a/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
+++ b/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework.Adapters</RepositoryUrl>
         <PackageId>Rystem.PlayFramework.Adapters</PackageId>
-        <Version>10.0.11-beta.14</Version>
+        <Version>10.0.11-beta.15</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);OPENAI001;AOAI001</NoWarn>

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework</RepositoryUrl>
     <PackageId>Rystem.PlayFramework</PackageId>
-    <Version>10.0.11-beta.14</Version>
+    <Version>10.0.11-beta.15</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs
@@ -145,10 +145,20 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         // Append query-string parameters
         var queryParts = _config.QueryParameters
             .Where(qp => argsDict.ContainsKey(qp.Name))
-            .Select(qp =>
+            .SelectMany(qp =>
             {
-                var raw = argsDict[qp.Name].GetString() ?? argsDict[qp.Name].GetRawText();
-                return $"{qp.Name}={Uri.EscapeDataString(raw)}";
+                var element = argsDict[qp.Name];
+
+                // Array values (e.g. List<Guid>) are expanded to repeated params:
+                // ["a","b"] → key=a&key=b  (ASP.NET Core model-binding convention)
+                if (element.ValueKind == JsonValueKind.Array)
+                {
+                    return element.EnumerateArray()
+                        .Select(v => $"{qp.Name}={Uri.EscapeDataString(v.GetString() ?? v.GetRawText())}");
+                }
+
+                var raw = element.GetString() ?? element.GetRawText();
+                return [$"{qp.Name}={Uri.EscapeDataString(raw)}"];
             });
 
         var queryString = string.Join("&", queryParts);
@@ -215,11 +225,9 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         // ── Query-string parameters ───────────────────────────────────────────
         foreach (var qp in _config.QueryParameters)
         {
-            properties[qp.Name] = new JsonObject
-            {
-                ["type"] = MapTypeToJsonSchemaType(qp.Type),
-                ["description"] = qp.Description
-            };
+            var qpNode = BuildJsonSchemaNode(qp.Type);
+            qpNode["description"] = qp.Description;
+            properties[qp.Name] = qpNode;
             // Query params are optional by default (not added to required)
         }
 
@@ -233,10 +241,7 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
                     continue;
 
                 var jsonName = GetJsonPropertyName(prop);
-                properties[jsonName] = new JsonObject
-                {
-                    ["type"] = MapTypeToJsonSchemaType(prop.PropertyType)
-                };
+                properties[jsonName] = BuildJsonSchemaNode(prop.PropertyType);
 
                 // Non-nullable value types are required
                 if (prop.PropertyType.IsValueType
@@ -258,38 +263,106 @@ internal sealed class EndpointHttpTool : ISceneTool, ISceneToolMetadata
         return JsonSerializer.Deserialize<JsonElement>(schema.ToJsonString());
     }
 
-    /// <summary>Maps a CLR type to its JSON Schema "type" string.</summary>
-    private static string MapTypeToJsonSchemaType(Type type)
+    /// <summary>
+    /// Builds a JSON Schema <see cref="JsonObject"/> node for the given CLR type.
+    /// For array / collection types the required <c>"items"</c> sub-schema is included
+    /// recursively so that the generated schema is valid for AI model APIs.
+    /// For enum types the valid names are listed in an <c>"enum"</c> array.
+    /// <see cref="Dictionary{TKey,TValue}"/> and other <c>IDictionary</c> types are
+    /// mapped to <c>"object"</c> rather than <c>"array"</c>.
+    /// </summary>
+    private static JsonObject BuildJsonSchemaNode(Type type)
     {
-        // Unwrap nullable
+        // Unwrap Nullable<T>: List<Guid>? → List<Guid>, int? → int
         var underlying = Nullable.GetUnderlyingType(type) ?? type;
 
-        if (underlying == typeof(bool)) return "boolean";
+        // ── Enum ─────────────────────────────────────────────────────────────
+        // Must be checked before IsArray / IEnumerable because Enum extends ValueType,
+        // not IEnumerable, but being explicit prevents any future ambiguity.
+        if (underlying.IsEnum)
+        {
+            var enumArray = new JsonArray();
+            foreach (var name in Enum.GetNames(underlying))
+                enumArray.Add(JsonValue.Create(name));
+            return new JsonObject
+            {
+                ["type"] = "string",
+                ["enum"] = enumArray
+            };
+        }
 
-        if (underlying == typeof(byte)
-            || underlying == typeof(sbyte)
-            || underlying == typeof(short)
-            || underlying == typeof(ushort)
-            || underlying == typeof(int)
-            || underlying == typeof(uint)
-            || underlying == typeof(long)
-            || underlying == typeof(ulong))
+        // ── T[] ──────────────────────────────────────────────────────────────
+        if (underlying.IsArray)
+        {
+            var elementType = underlying.GetElementType()!;
+            return new JsonObject
+            {
+                ["type"] = "array",
+                ["items"] = BuildJsonSchemaNode(elementType)
+            };
+        }
+
+        // ── IDictionary / Dictionary<K,V> → object ───────────────────────────
+        // Must be checked BEFORE the generic IEnumerable branch, because
+        // Dictionary<K,V> also implements IEnumerable<KeyValuePair<K,V>> and
+        // would otherwise be misidentified as an array.
+        // Covers: System.Collections.IDictionary (non-generic), IDictionary<K,V>
+        // (generic interface itself), and any concrete type that implements it
+        // (Dictionary<K,V>, SortedDictionary<K,V>, ConcurrentDictionary<K,V>, …).
+        if (typeof(System.Collections.IDictionary).IsAssignableFrom(underlying)
+            || (underlying.IsGenericType
+                && underlying.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IDictionary<,>))
+            || underlying.GetInterfaces().Any(i =>
+                i.IsGenericType
+                && i.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IDictionary<,>)))
+        {
+            return new JsonObject { ["type"] = "object" };
+        }
+
+        // ── IEnumerable<T>: List<T>, ICollection<T>, IReadOnlyList<T>, etc. ──
+        if (underlying.IsGenericType
+            && typeof(System.Collections.IEnumerable).IsAssignableFrom(underlying))
+        {
+            var elementType = underlying.GetGenericArguments()[0];
+            return new JsonObject
+            {
+                ["type"] = "array",
+                ["items"] = BuildJsonSchemaNode(elementType)
+            };
+        }
+
+        // ── Scalar types ─────────────────────────────────────────────────────
+        return new JsonObject { ["type"] = MapScalarTypeToJsonSchemaType(underlying) };
+    }
+
+    /// <summary>
+    /// Maps a non-collection, already-unwrapped CLR type to its JSON Schema scalar
+    /// type string: <c>"boolean"</c>, <c>"integer"</c>, <c>"number"</c>,
+    /// <c>"object"</c>, or <c>"string"</c>.
+    /// </summary>
+    private static string MapScalarTypeToJsonSchemaType(Type type)
+    {
+        if (type == typeof(bool)) return "boolean";
+
+        if (type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong))
             return "integer";
 
-        if (underlying == typeof(float)
-            || underlying == typeof(double)
-            || underlying == typeof(decimal))
+        if (type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal))
             return "number";
 
-        if (underlying.IsArray
-            || (underlying.IsGenericType
-                && typeof(System.Collections.IEnumerable).IsAssignableFrom(underlying)))
-            return "array";
-
-        if (underlying.IsClass && underlying != typeof(string))
+        if (type.IsClass && type != typeof(string))
             return "object";
 
-        // string, Guid, DateTime, DateTimeOffset, Uri, enums → "string"
+        // string, Guid, DateTime, DateTimeOffset, DateOnly, Uri, enums → "string"
         return "string";
     }
 

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs
@@ -105,6 +105,75 @@ internal sealed class OrderResponse
     public string Status { get; set; } = "";
 }
 
+/// <summary>
+/// Request DTO with nullable <see cref="List{T}"/> of <see cref="Guid"/> — the scenario
+/// that was producing "array schema missing items" when sent to AI model APIs.
+/// </summary>
+internal sealed class FindByGuidsRequest
+{
+    [System.Text.Json.Serialization.JsonPropertyName("projectIds")]
+    public List<Guid>? ProjectIds { get; set; } = [];
+
+    [System.Text.Json.Serialization.JsonPropertyName("entityIds")]
+    public List<Guid>? EntityIds { get; set; } = [];
+}
+
+/// <summary>
+/// Request DTO that covers all collection variants to be supported.
+/// </summary>
+internal sealed class CollectionTypesRequest
+{
+    [System.Text.Json.Serialization.JsonPropertyName("guidList")]
+    public List<Guid>? GuidList { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("intList")]
+    public List<int> IntList { get; set; } = [];
+
+    [System.Text.Json.Serialization.JsonPropertyName("stringArray")]
+    public string[] StringArray { get; set; } = [];
+
+    [System.Text.Json.Serialization.JsonPropertyName("enumerable")]
+    public IEnumerable<string>? Enumerable { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("readOnlyList")]
+    public IReadOnlyList<decimal>? ReadOnlyList { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("collection")]
+    public ICollection<bool>? Collection { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("scalar")]
+    public string? Scalar { get; set; }
+}
+
+internal enum SortOrder { Ascending, Descending, Relevance }
+
+/// <summary>
+/// Request DTO with an enum property, to verify "enum":[names] in schema.
+/// </summary>
+internal sealed class SortedSearchRequest
+{
+    [System.Text.Json.Serialization.JsonPropertyName("query")]
+    public string? Query { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("sortOrder")]
+    public SortOrder SortOrder { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("nullableSortOrder")]
+    public SortOrder? NullableSortOrder { get; set; }
+}
+
+/// <summary>
+/// Request DTO with a Dictionary property, to verify it maps to "object" not "array".
+/// </summary>
+internal sealed class MetadataRequest
+{
+    [System.Text.Json.Serialization.JsonPropertyName("metadata")]
+    public Dictionary<string, string>? Metadata { get; set; }
+
+    [System.Text.Json.Serialization.JsonPropertyName("counts")]
+    public IDictionary<string, int>? Counts { get; set; }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 public sealed class EndpointHttpToolTests
@@ -399,6 +468,288 @@ public sealed class EndpointHttpToolTests
         Assert.Contains("quantity", required);
         Assert.DoesNotContain("totalPrice", required);
         Assert.DoesNotContain("customerName", required);
+    }
+
+    // ── Group 2b: Schema – array / collection "items" ─────────────────────────
+
+    /// <summary>
+    /// Regression test for "array schema missing items".
+    /// List&lt;Guid&gt;? must produce { "type": "array", "items": { "type": "string" } }.
+    /// </summary>
+    [Fact]
+    public void Schema_Post_NullableListGuid_ArrayHasItemsTypeString()
+    {
+        var (props, _) = BuildSchemaProps<FindByGuidsRequest>();
+
+        Assert.True(props.TryGetProperty("projectIds", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        var items = prop.GetProperty("items");
+        Assert.Equal("string", items.GetProperty("type").GetString());
+    }
+
+    /// <summary>
+    /// A second nullable List&lt;Guid&gt; in the same DTO must also have "items".
+    /// </summary>
+    [Fact]
+    public void Schema_Post_SecondNullableListGuid_ArrayHasItemsTypeString()
+    {
+        var (props, _) = BuildSchemaProps<FindByGuidsRequest>();
+
+        Assert.True(props.TryGetProperty("entityIds", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("string", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_ListInt_ArrayHasItemsTypeInteger()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        Assert.True(props.TryGetProperty("intList", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("integer", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_StringArray_ArrayHasItemsTypeString()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        Assert.True(props.TryGetProperty("stringArray", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("string", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_NullableIEnumerableString_ArrayHasItemsTypeString()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        Assert.True(props.TryGetProperty("enumerable", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("string", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_NullableIReadOnlyListDecimal_ArrayHasItemsTypeNumber()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        Assert.True(props.TryGetProperty("readOnlyList", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("number", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_NullableICollectionBool_ArrayHasItemsTypeBoolean()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        Assert.True(props.TryGetProperty("collection", out var prop));
+        Assert.Equal("array", prop.GetProperty("type").GetString());
+        Assert.Equal("boolean", prop.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void Schema_Post_NullableListGuid_ScalarSiblingIsUnaffected()
+    {
+        var (props, _) = BuildSchemaProps<CollectionTypesRequest>();
+
+        // A plain scalar property alongside lists must still be a simple "string"
+        Assert.True(props.TryGetProperty("scalar", out var prop));
+        Assert.Equal("string", prop.GetProperty("type").GetString());
+        Assert.False(prop.TryGetProperty("items", out _));
+    }
+
+    /// <summary>
+    /// A query-string parameter declared with a List type must also produce
+    /// { "type": "array", "items": { "type": "string" } }.
+    /// </summary>
+    [Fact]
+    public void Schema_QueryParam_ListType_ArrayHasItems()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("SearchOrders", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>("SearchOrders", HttpMethod.Get, "/orders", "Search orders")
+                      .WithParameter("ids", "Filter by ids", typeof(List<Guid>));
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Orders")!.Tools[0];
+        var schema = GetAiToolJsonSchema(tool.ToolDescription);
+        using var doc = JsonDocument.Parse(schema.GetRawText());
+        var props = doc.RootElement.GetProperty("properties");
+
+        Assert.True(props.TryGetProperty("ids", out var idsProp));
+        Assert.Equal("array", idsProp.GetProperty("type").GetString());
+        Assert.Equal("string", idsProp.GetProperty("items").GetProperty("type").GetString());
+    }
+
+    // ── Helper: build schema properties for a typed request body ─────────────
+
+    private (JsonElement properties, List<string> required) BuildSchemaProps<TRequest>()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient("Action", []));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(c => c.BaseAddress = new Uri("http://api/"));
+
+            builder.AddScene("Test", "Test scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<TRequest, OrderResponse>("Action", HttpMethod.Post, "/action", "Test action");
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var tool = sp.GetRequiredService<ISceneFactory>().TryGetScene("Test")!.Tools[0];
+        var schema = GetAiToolJsonSchema(tool.ToolDescription);
+        using var doc = JsonDocument.Parse(schema.GetRawText());
+
+        var props = doc.RootElement.GetProperty("properties").Clone();
+        var required = doc.RootElement.TryGetProperty("required", out var req)
+            ? req.EnumerateArray().Select(e => e.GetString()!).ToList()
+            : new List<string>();
+        return (props, required);
+    }
+
+    // ── Group 2c: Schema – enum "enum" values ─────────────────────────────────
+
+    [Fact]
+    public void Schema_Post_EnumProperty_HasTypeStringAndEnumValues()
+    {
+        var (props, _) = BuildSchemaProps<SortedSearchRequest>();
+
+        Assert.True(props.TryGetProperty("sortOrder", out var prop));
+        Assert.Equal("string", prop.GetProperty("type").GetString());
+
+        var values = prop.GetProperty("enum").EnumerateArray()
+            .Select(e => e.GetString()).ToList();
+        Assert.Contains("Ascending", values);
+        Assert.Contains("Descending", values);
+        Assert.Contains("Relevance", values);
+    }
+
+    [Fact]
+    public void Schema_Post_NullableEnumProperty_HasEnumValues()
+    {
+        var (props, _) = BuildSchemaProps<SortedSearchRequest>();
+
+        Assert.True(props.TryGetProperty("nullableSortOrder", out var prop));
+        Assert.Equal("string", prop.GetProperty("type").GetString());
+        var values = prop.GetProperty("enum").EnumerateArray()
+            .Select(e => e.GetString()).ToList();
+        Assert.Equal(3, values.Count);
+    }
+
+    [Fact]
+    public void Schema_Post_EnumProperty_IsRequiredWhenNonNullable()
+    {
+        var (_, required) = BuildSchemaProps<SortedSearchRequest>();
+        Assert.Contains("sortOrder", required);
+        Assert.DoesNotContain("nullableSortOrder", required);
+    }
+
+    // ── Group 2d: Schema – Dictionary → "object" ──────────────────────────────
+
+    [Fact]
+    public void Schema_Post_DictionaryStringString_HasTypeObject()
+    {
+        var (props, _) = BuildSchemaProps<MetadataRequest>();
+
+        Assert.True(props.TryGetProperty("metadata", out var prop));
+        Assert.Equal("object", prop.GetProperty("type").GetString());
+        Assert.False(prop.TryGetProperty("items", out _));
+    }
+
+    [Fact]
+    public void Schema_Post_IDictionaryStringInt_HasTypeObject()
+    {
+        var (props, _) = BuildSchemaProps<MetadataRequest>();
+
+        Assert.True(props.TryGetProperty("counts", out var prop));
+        Assert.Equal("object", prop.GetProperty("type").GetString());
+        Assert.False(prop.TryGetProperty("items", out _));
+    }
+
+    // ── Group 3b: Execution – array query param expands to repeated key=val ───
+
+    [Fact]
+    public async Task Execution_ArrayQueryParam_ExpandsToRepeatedQueryStringPairs()
+    {
+        var responsePayload = """{"orderId":"x","status":"Ok"}""";
+        var handler = new CapturingHttpHandler(
+            new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(responsePayload, Encoding.UTF8, "application/json")
+            });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IChatClient>(new EndpointToolCallingChatClient(
+            "SearchOrders",
+            new Dictionary<string, object?>
+            {
+                // The AI sends the array as a JSON array value
+                ["ids"] = JsonSerializer.Deserialize<JsonElement>("""["id-1","id-2","id-3"]""")
+            }));
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.WithHttpClient<IOrderServiceClient>(
+                c => c.BaseAddress = new Uri("http://api/"),
+                b => b.ConfigurePrimaryHttpMessageHandler(() => handler));
+
+            builder.AddScene("Orders", "Orders scene", scene =>
+            {
+                scene.WithEndpoint<IOrderServiceClient>(ep =>
+                {
+                    ep.WithAction<OrderResponse>(
+                            "SearchOrders", HttpMethod.Get, "/orders", "Search orders")
+                        .WithParameter("ids", "Filter by order ids", typeof(List<string>));
+                });
+            });
+        });
+
+        var sp = services.BuildServiceProvider();
+        var sceneManager = sp.GetRequiredService<IFactory<ISceneManager>>().Create(null)!;
+
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Scene,
+            SceneName = "Orders"
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("find orders with ids id-1 id-2 id-3", settings: settings)) { }
+
+        var capturedUrl = handler.CapturedRequest?.RequestUri?.ToString();
+        Assert.NotNull(capturedUrl);
+
+        // Must NOT contain raw JSON brackets
+        Assert.DoesNotContain("%5B", capturedUrl);   // [
+        Assert.DoesNotContain("%5D", capturedUrl);   // ]
+
+        // Each id must appear as a separate repeated param
+        Assert.Contains("ids=id-1", capturedUrl);
+        Assert.Contains("ids=id-2", capturedUrl);
+        Assert.Contains("ids=id-3", capturedUrl);
     }
 
     // ── Group 3: Metadata ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes multiple JSON Schema generation bugs in `EndpointHttpTool` that caused AI model APIs (OpenAI, Azure OpenAI) to reject tool definitions with `invalid_function_parameters` errors.

---

## Problems fixed

### 1. Array / collection types missing `items`

Properties of type `List<T>`, `T[]`, `IEnumerable<T>`, `ICollection<T>`, `IReadOnlyList<T>`, etc. were emitting only `{ "type": "array" }`.
JSON Schema requires `items` to be present whenever `type` is `array`. AI model APIs enforce this strictly.

**Before**
```json
{ "projectIds": { "type": "array" } }
```
**After**
```json
{ "projectIds": { "type": "array", "items": { "type": "string" } } }
```

### 2. Enum properties missing valid values

Enum properties fell through to the `"string"` fallback with no hint of valid values, so the AI model would generate arbitrary strings instead of choosing from the allowed set.

**Before**
```json
{ "orderBy": { "type": "string" } }
```
**After**
```json
{ "orderBy": { "type": "string", "enum": ["Start", "End", "Name"] } }
```

### 3. `Dictionary<K,V>` incorrectly mapped as `array`

Because `Dictionary<K,V>` implements `IEnumerable<KeyValuePair<K,V>>`, the generic `IEnumerable` check fired first, producing a nonsensical array schema. Dictionary types now correctly map to `{ "type": "object" }`.

Covers `Dictionary<K,V>`, `IDictionary<K,V>`, `SortedDictionary<K,V>`, `ConcurrentDictionary<K,V>`.

### 4. Query-string array parameters serialized as raw JSON in the URL

When a query parameter of array type received a JSON array value from the AI, `BuildUrl` placed the raw JSON literal in the query string instead of expanding it:

```
/orders?ids=%5B%22id-1%22%2C%22id-2%22%5D   ← wrong
/orders?ids=id-1&ids=id-2&ids=id-3          ← correct (ASP.NET Core convention)
```

---

## Changes

### `src/AI/Rystem.PlayFramework/Services/Tools/EndpointHttpTool.cs`

- Replaced `MapTypeToJsonSchemaType(Type) → string` with `BuildJsonSchemaNode(Type) → JsonObject` which handles all type cases correctly and is applied recursively for nested collections.
- Added `IDictionary` detection before the `IEnumerable` branch to prevent dictionaries from being misclassified as arrays.
- `BuildUrl` uses `SelectMany` + `JsonValueKind.Array` detection to expand array values into repeated query-string pairs.

### `src/AI/Test/Rystem.PlayFramework.Test/Tests/EndpointHttpToolTests.cs`

Added **16 new tests** covering all fixed scenarios:

| Group | Tests |
|---|---|
| 2b – Array `items` | `List<Guid>?`, `List<int>`, `string[]`, `IEnumerable<string>?`, `IReadOnlyList<decimal>?`, `ICollection<bool>?`, scalar sibling unaffected, query param with list type |
| 2c – Enum values | Non-nullable enum has `"enum"` array, nullable enum has `"enum"` array, non-nullable enum is required |
| 2d – Dictionary | `Dictionary<string,string>` → `object`, `IDictionary<string,int>` → `object` |
| 3b – URL expansion | Array query param expands to repeated `key=val` pairs |

---

## Version

`Rystem.PlayFramework` and `Rystem.PlayFramework.Adapters` bumped to **10.0.11-beta.15**.
