### PR TITLE
Fix: conversation caching

### DIFF
--- a/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
+++ b/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework.Adapters</RepositoryUrl>
         <PackageId>Rystem.PlayFramework.Adapters</PackageId>
-        <Version>10.0.11-beta.16</Version>
+        <Version>10.0.11-beta.17</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);OPENAI001;AOAI001</NoWarn>

--- a/src/AI/Rystem.PlayFramework/Domain/Models/StoredMessage.cs
+++ b/src/AI/Rystem.PlayFramework/Domain/Models/StoredMessage.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 using Rystem.PlayFramework.Helpers;
 
@@ -64,7 +63,7 @@ public sealed class StoredMessage
         };
 
         // Convert complex contents to serializable format
-        if (message.Contents != null && message.Contents.Count > 0)
+        if (message.Contents.Count > 0)
         {
             cached.Contents = [];
             foreach (var content in message.Contents)
@@ -147,10 +146,7 @@ public sealed class StoredMessage
         if (label == "InitialContext" || label?.StartsWith("SceneActor:", StringComparison.Ordinal) == true || label?.StartsWith("McpContext:", StringComparison.Ordinal) == true)
             return MessageBusinessType.Message | MessageBusinessType.Store;
 
-        if (label == "User" || role == "user")
-            return MessageBusinessType.Message | MessageBusinessType.Store | MessageBusinessType.Memory | MessageBusinessType.Resume;
-
-        if (label == "Assistant" || role == "assistant")
+        if (label == "User" || role == "user" || label == "Assistant" || role == "assistant")
             return MessageBusinessType.Message | MessageBusinessType.Store | MessageBusinessType.Memory | MessageBusinessType.Resume;
 
         if (label == "Tool" || role == "tool")

--- a/src/AI/Rystem.PlayFramework/Domain/Models/StoredMessage.cs
+++ b/src/AI/Rystem.PlayFramework/Domain/Models/StoredMessage.cs
@@ -17,6 +17,12 @@ public sealed class StoredMessage
     public MessageBusinessType BusinessType { get; set; }
 
     /// <summary>
+    /// Numeric backup value for BusinessType.
+    /// Helps preserve flags across different JSON enum serialization modes.
+    /// </summary>
+    public int? BusinessTypeValue { get; set; }
+
+    /// <summary>
     /// Label for debugging.
     /// </summary>
     public string? Label { get; set; }
@@ -50,6 +56,7 @@ public sealed class StoredMessage
         var cached = new StoredMessage
         {
             BusinessType = tracked.BusinessType,
+            BusinessTypeValue = (int)tracked.BusinessType,
             Label = tracked.Label,
             Role = message.Role.Value,
             Text = message.Text,
@@ -74,6 +81,8 @@ public sealed class StoredMessage
     /// </summary>
     public TrackedMessage ToTrackedMessage()
     {
+        var resolvedBusinessType = ResolveBusinessType(BusinessType, BusinessTypeValue, Label, Role);
+
         var role = Role switch
         {
             "user" => ChatRole.User,
@@ -108,10 +117,46 @@ public sealed class StoredMessage
 
         return new TrackedMessage
         {
-            BusinessType = BusinessType,
+            BusinessType = resolvedBusinessType,
             Label = Label,
             Message = message
         };
+    }
+
+    private static MessageBusinessType ResolveBusinessType(
+        MessageBusinessType businessType,
+        int? businessTypeValue,
+        string? label,
+        string role)
+    {
+        if (businessType != MessageBusinessType.None)
+            return businessType;
+
+        if (businessTypeValue.HasValue)
+        {
+            var fromNumeric = (MessageBusinessType)businessTypeValue.Value;
+            if (fromNumeric != MessageBusinessType.None)
+                return fromNumeric;
+        }
+
+        return InferBusinessTypeFromLabelOrRole(label, role);
+    }
+
+    private static MessageBusinessType InferBusinessTypeFromLabelOrRole(string? label, string role)
+    {
+        if (label == "InitialContext" || label?.StartsWith("SceneActor:", StringComparison.Ordinal) == true || label?.StartsWith("McpContext:", StringComparison.Ordinal) == true)
+            return MessageBusinessType.Message | MessageBusinessType.Store;
+
+        if (label == "User" || role == "user")
+            return MessageBusinessType.Message | MessageBusinessType.Store | MessageBusinessType.Memory | MessageBusinessType.Resume;
+
+        if (label == "Assistant" || role == "assistant")
+            return MessageBusinessType.Message | MessageBusinessType.Store | MessageBusinessType.Memory | MessageBusinessType.Resume;
+
+        if (label == "Tool" || role == "tool")
+            return MessageBusinessType.Message | MessageBusinessType.Store | MessageBusinessType.Resume;
+
+        return MessageBusinessType.None;
     }
 }
 

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework</RepositoryUrl>
     <PackageId>Rystem.PlayFramework</PackageId>
-    <Version>10.0.11-beta.16</Version>
+    <Version>10.0.11-beta.17</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
+++ b/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
@@ -1,10 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Rystem.PlayFramework.Services;
 using Rystem.PlayFramework.Services.ExecutionModes;
 using Rystem.PlayFramework.Services.Helpers;
 using Rystem.PlayFramework.Telemetry;

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs
@@ -343,6 +343,69 @@ public sealed class ConversationCacheTests
             m.Role == ChatRole.System && m.Text != null && m.Text.Contains("Execution Checkpoint"));
     }
 
+    [Fact]
+    public void StoredMessage_ToTrackedMessage_WhenBusinessTypeMissing_UsesNumericBackup()
+    {
+        // Arrange
+        var stored = new StoredMessage
+        {
+            BusinessType = MessageBusinessType.None,
+            BusinessTypeValue = (int)(MessageBusinessType.Message | MessageBusinessType.Store),
+            Label = "InitialContext",
+            Role = "system",
+            Text = "ctx"
+        };
+
+        // Act
+        var tracked = stored.ToTrackedMessage();
+
+        // Assert
+        Assert.True(tracked.IsActiveMessage);
+        Assert.True(tracked.ShouldStore);
+    }
+
+    [Fact]
+    public void LoadFromStoredConversation_WhenBusinessTypeMissingForLegacyMessages_RecoversFlagsFromLabel()
+    {
+        // Arrange
+        var stored = new StoredConversation
+        {
+            ConversationKey = "legacy-flags",
+            UserId = null,
+            IsPublic = true,
+            Timestamp = DateTime.UtcNow,
+            Messages =
+            [
+                new StoredMessage { BusinessType = MessageBusinessType.None, BusinessTypeValue = null, Label = "InitialContext", Role = "system", Text = "System prompt" },
+                new StoredMessage { BusinessType = MessageBusinessType.None, BusinessTypeValue = null, Label = "User", Role = "user", Text = "Turn 1 question" },
+                new StoredMessage { BusinessType = MessageBusinessType.None, BusinessTypeValue = null, Label = "Assistant", Role = "assistant", Text = "Turn 1 answer" },
+            ],
+            ExecutionState = new ExecutionState { Phase = ExecutionPhase.Completed }
+        };
+
+        var context = new SceneContext
+        {
+            ServiceProvider = null!,
+            Input = MultiModalInput.FromText("Turn 2 question"),
+            ChatClientManager = null!
+        };
+
+        // Act
+        context.LoadFromStoredConversation(stored);
+        context.AddUserMessage(context.Input);
+
+        var llmMessages = context.GetMessagesForLLM();
+        var storeMessages = context.GetMessagesToStore();
+
+        // Assert
+        Assert.Equal(4, llmMessages.Count);
+        Assert.Equal(4, storeMessages.Count);
+        Assert.Equal("InitialContext", context.ConversationHistory[0].Label);
+        Assert.Equal("User", context.ConversationHistory[1].Label);
+        Assert.Equal("Assistant", context.ConversationHistory[2].Label);
+        Assert.Equal("User", context.ConversationHistory[3].Label);
+    }
+
     #endregion
 
     #region Integration Tests (full pipeline with cache)


### PR DESCRIPTION
## What changed
- Fixed cache reload behavior so previously saved conversation messages remain active and storable on subsequent turns.
- Hardened `StoredMessage` deserialization for `BusinessType` flags with a safe resolution strategy:
  - use `BusinessType` when present,
  - fallback to numeric `BusinessTypeValue`,
  - final fallback inferred from `Label`/`Role` for legacy payloads.
- Added `BusinessTypeValue` as numeric backup during serialization to make Redis roundtrips resilient across enum serialization modes.
- Kept the diagnostic `[CacheDiag]` logs out of the final patch (cleanup completed).

## Why
In multi-turn conversations with Redis cache, messages loaded from cache could end up with `BusinessType=None`, which made them:
- not sent back to the LLM (`IsActiveMessage=false`), and
- not persisted again on save (`ShouldStore=false`).

This caused turn-1 history to disappear after turn-2 save. The fix guarantees message flags are recovered correctly and conversation continuity is preserved.

## Tests
Added regression tests in `src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs`:
- `StoredMessage_ToTrackedMessage_WhenBusinessTypeMissing_UsesNumericBackup`
- `LoadFromStoredConversation_WhenBusinessTypeMissingForLegacyMessages_RecoversFlagsFromLabel`

Executed tests:
- targeted regression tests: **passed** (2/2)
- full `Rystem.PlayFramework.Test` suite: **passed**  (188 tests) (0 failed; skipped integration tests as configured)