### PR TITLE
fix(play-framework): remove invalid SSE Connection header

### DIFF
--- a/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
+++ b/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework.Adapters</RepositoryUrl>
         <PackageId>Rystem.PlayFramework.Adapters</PackageId>
-        <Version>10.0.11-beta.17</Version>
+        <Version>10.0.11-beta.18</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);OPENAI001;AOAI001</NoWarn>

--- a/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
+++ b/src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs
@@ -356,7 +356,6 @@ public static class WebApplicationExtensions
                 {
                     httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
                     httpContext.Response.Headers.Append("Cache-Control", "no-cache");
-                    httpContext.Response.Headers.Append("Connection", "keep-alive");
                     sseHeadersWritten = true;
                 }
 
@@ -1093,7 +1092,6 @@ public static class WebApplicationExtensions
             // Set response headers for SSE
             httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
             httpContext.Response.Headers.Append("Cache-Control", "no-cache");
-            httpContext.Response.Headers.Append("Connection", "keep-alive");
 
             // Stream voice pipeline responses as SSE events
             await foreach (var voiceResponse in pipeline.ProcessAsync(audioData, audioFile.FileName, metadata, requestSettings, cancellationToken))
@@ -1166,4 +1164,3 @@ public static class WebApplicationExtensions
         }
     }
 }
-

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework</RepositoryUrl>
     <PackageId>Rystem.PlayFramework</PackageId>
-    <Version>10.0.11-beta.17</Version>
+    <Version>10.0.11-beta.18</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
This PR removes the `Connection: keep-alive` header from Server-Sent Events (SSE) responses in `Rystem.PlayFramework`.

For HTTP/2 and HTTP/3, `Connection` is a hop-by-hop header and is invalid by spec. Kestrel strips it and logs warnings (`Microsoft.AspNetCore.Server.Kestrel[41]`).

## Changes
- Removed `Connection: keep-alive` from SSE responses in:
  - `src/AI/Rystem.PlayFramework/Api/WebApplicationExtensions.cs`
    - completions SSE flow
    - voice SSE flow
- Kept valid SSE headers unchanged:
  - `Content-Type: text/event-stream`
  - `Cache-Control: no-cache`

## Why
- Aligns SSE responses with HTTP/2 and HTTP/3 requirements.
- Removes noisy Kestrel warnings without changing runtime behavior.

## Impact
- No breaking changes.
- No API contract changes.
- Streaming behavior is unchanged.
- Cleaner server logs (no invalid response header warnings).

## Validation
- Trigger an SSE request (for example `/api/completions/default`).
- Confirm streaming still works as expected.
- Confirm Kestrel no longer logs invalid HTTP/2/HTTP/3 header warnings for these endpoints.
