### PR TITLE
fix(play-framework): propagate token usage to terminal completed events

### DIFF
--- a/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
+++ b/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework.Adapters</RepositoryUrl>
         <PackageId>Rystem.PlayFramework.Adapters</PackageId>
-        <Version>10.0.11-beta.18</Version>
+        <Version>10.0.11-beta.19</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);OPENAI001;AOAI001</NoWarn>

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework</RepositoryUrl>
     <PackageId>Rystem.PlayFramework</PackageId>
-    <Version>10.0.11-beta.18</Version>
+    <Version>10.0.11-beta.19</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/AI/Rystem.PlayFramework/Services/Helpers/ResponseHelper.cs
+++ b/src/AI/Rystem.PlayFramework/Services/Helpers/ResponseHelper.cs
@@ -50,6 +50,7 @@ internal sealed class ResponseHelper : IResponseHelper
             InputTokens = inputTokens,
             OutputTokens = outputTokens,
             CachedInputTokens = cachedInputTokens,
+            TotalTokens = ComputeTotalTokens(inputTokens, outputTokens, cachedInputTokens),
             Cost = cost,
             TotalCost = context.AddCost(cost ?? 0),
             Contents = contents
@@ -92,6 +93,7 @@ internal sealed class ResponseHelper : IResponseHelper
             InputTokens = inputTokens,
             OutputTokens = outputTokens,
             CachedInputTokens = cachedInputTokens,
+            TotalTokens = ComputeTotalTokens(inputTokens, outputTokens, cachedInputTokens),
             Cost = cost,
             TotalCost = context.AddCost(cost ?? 0),
             Contents = contents
@@ -158,6 +160,7 @@ internal sealed class ResponseHelper : IResponseHelper
             InputTokens = inputTokens,
             OutputTokens = outputTokens,
             CachedInputTokens = cachedInputTokens,
+            TotalTokens = ComputeTotalTokens(inputTokens, outputTokens, cachedInputTokens),
             Cost = cost,
             TotalCost = context.AddCost(cost ?? 0),
             FunctionName = functionName,
@@ -168,5 +171,15 @@ internal sealed class ResponseHelper : IResponseHelper
         context.Responses.Add(response);
 
         return response;
+    }
+
+    private static int? ComputeTotalTokens(int? inputTokens, int? outputTokens, int? cachedInputTokens)
+    {
+        if (!inputTokens.HasValue && !outputTokens.HasValue && !cachedInputTokens.HasValue)
+        {
+            return null;
+        }
+
+        return (inputTokens ?? 0) + (outputTokens ?? 0) + (cachedInputTokens ?? 0);
     }
 }

--- a/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
+++ b/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
@@ -891,10 +891,29 @@ internal sealed class SceneManager : ISceneManager, IFactoryName
             // Only send Completed if NOT waiting for client interaction
             // For Commands (CommandClient status), client closes stream on its side after execution
             // If feedbackMode requires response, client includes CommandResult in next user message
-            yield return YieldStatus(AiResponseStatus.Completed, "Execution completed", context.TotalCost, context.ConversationKey);
+            yield return YieldStatus(
+                status: AiResponseStatus.Completed,
+                message: "Execution completed",
+                cost: context.TotalCost,
+                conversationKey: context.ConversationKey,
+                inputTokens: lastResponse?.InputTokens,
+                outputTokens: lastResponse?.OutputTokens,
+                cachedInputTokens: lastResponse?.CachedInputTokens,
+                totalTokens: lastResponse?.TotalTokens
+                    ?? ((lastResponse?.InputTokens ?? 0)
+                        + (lastResponse?.OutputTokens ?? 0)
+                        + (lastResponse?.CachedInputTokens ?? 0)));
         }
     }
-    private AiSceneResponse YieldStatus(AiResponseStatus status, string? message = null, decimal? cost = null, string? conversationKey = null)
+    private AiSceneResponse YieldStatus(
+        AiResponseStatus status,
+        string? message = null,
+        decimal? cost = null,
+        string? conversationKey = null,
+        int? inputTokens = null,
+        int? outputTokens = null,
+        int? cachedInputTokens = null,
+        int? totalTokens = null)
     {
         return new AiSceneResponse
         {
@@ -902,7 +921,11 @@ internal sealed class SceneManager : ISceneManager, IFactoryName
             Message = message,
             Cost = cost,
             TotalCost = cost ?? 0,
-            ConversationKey = conversationKey
+            ConversationKey = conversationKey,
+            InputTokens = inputTokens,
+            OutputTokens = outputTokens,
+            CachedInputTokens = cachedInputTokens,
+            TotalTokens = totalTokens
         };
     }
     private AiSceneResponse YieldAndTrack(SceneContext context, AiSceneResponse response)

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/TokenPropagationTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/TokenPropagationTests.cs
@@ -1,0 +1,157 @@
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rystem.PlayFramework.Test.Tests;
+
+public class TokenPropagationTests
+{
+    [Fact]
+    public async Task FinalResponse_And_Completed_ShouldCarryTokenCounters()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddPlayFramework(builder =>
+        {
+            builder
+                .WithExecutionMode(SceneExecutionMode.Direct)
+                .AddScene("Calculator", "Simple calculator", sceneBuilder =>
+                {
+                    sceneBuilder.WithService<ITokenMathService>(serviceBuilder =>
+                    {
+                        serviceBuilder.WithMethod(x => x.AddAsync(default, default), "add", "Add two numbers");
+                    });
+                });
+        });
+
+        services.AddSingleton<ITokenMathService, TokenMathService>();
+        services.AddSingleton<IChatClient>(new MockTokenChatClient(
+            sceneInputTokens: 100,
+            sceneOutputTokens: 20,
+            sceneCachedInputTokens: 30));
+
+        var provider = services.BuildServiceProvider();
+        var sceneManager = provider.GetRequiredService<ISceneManager>();
+
+        var responses = new List<AiSceneResponse>();
+        await foreach (var response in sceneManager.ExecuteAsync(
+            message: "quanto fa 2 + 2?",
+            settings: new SceneRequestSettings
+            {
+                ExecutionMode = SceneExecutionMode.Direct,
+                EnableStreaming = false
+            }))
+        {
+            responses.Add(response);
+        }
+
+        var finalResponse = responses.Last(r => r.Status == AiResponseStatus.FinalResponse);
+        var completed = responses.Last(r => r.Status == AiResponseStatus.Completed);
+
+        Assert.Equal(100, finalResponse.InputTokens);
+        Assert.Equal(20, finalResponse.OutputTokens);
+        Assert.Equal(30, finalResponse.CachedInputTokens);
+        Assert.Equal(150, finalResponse.TotalTokens);
+
+        Assert.Equal(finalResponse.InputTokens, completed.InputTokens);
+        Assert.Equal(finalResponse.OutputTokens, completed.OutputTokens);
+        Assert.Equal(finalResponse.CachedInputTokens, completed.CachedInputTokens);
+        Assert.Equal(finalResponse.TotalTokens, completed.TotalTokens);
+    }
+
+    private interface ITokenMathService
+    {
+        Task<double> AddAsync(double a, double b);
+    }
+
+    private sealed class TokenMathService : ITokenMathService
+    {
+        public Task<double> AddAsync(double a, double b) => Task.FromResult(a + b);
+    }
+
+    private sealed class MockTokenChatClient : IChatClient
+    {
+        private readonly int _sceneInputTokens;
+        private readonly int _sceneOutputTokens;
+        private readonly int _sceneCachedInputTokens;
+        private int _callCount;
+
+        public MockTokenChatClient(int sceneInputTokens, int sceneOutputTokens, int sceneCachedInputTokens)
+        {
+            _sceneInputTokens = sceneInputTokens;
+            _sceneOutputTokens = sceneOutputTokens;
+            _sceneCachedInputTokens = sceneCachedInputTokens;
+        }
+
+        public ChatClientMetadata Metadata => new("mock-token-client", null, "mock-1.0");
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            _callCount++;
+
+            var responseMessage = _callCount == 1
+                ? BuildSceneSelectionMessage(options)
+                : new ChatMessage(ChatRole.Assistant, "Risultato: 4");
+
+            var usage = _callCount == 1
+                ? new UsageDetails
+                {
+                    InputTokenCount = 1,
+                    OutputTokenCount = 1,
+                    CachedInputTokenCount = 0,
+                    TotalTokenCount = 2
+                }
+                : new UsageDetails
+                {
+                    InputTokenCount = _sceneInputTokens,
+                    OutputTokenCount = _sceneOutputTokens,
+                    CachedInputTokenCount = _sceneCachedInputTokens,
+                    TotalTokenCount = _sceneInputTokens + _sceneOutputTokens + _sceneCachedInputTokens
+                };
+
+            var response = new ChatResponse([responseMessage])
+            {
+                ModelId = "mock-model",
+                Usage = usage
+            };
+
+            return Task.FromResult(response);
+        }
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, "unused in this test")
+            {
+                FinishReason = ChatFinishReason.Stop
+            };
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+        }
+
+        private static ChatMessage BuildSceneSelectionMessage(ChatOptions? options)
+        {
+            var selectedScene = options?.Tools?.FirstOrDefault();
+            var selectedSceneName = selectedScene?.GetType().GetProperty("Name")?.GetValue(selectedScene)?.ToString() ?? "Calculator";
+
+            var functionCall = new FunctionCallContent(
+                callId: Guid.NewGuid().ToString(),
+                name: selectedSceneName,
+                arguments: new Dictionary<string, object?>());
+
+            var message = new ChatMessage(ChatRole.Assistant, string.Empty);
+            message.Contents.Add(functionCall);
+            return message;
+        }
+    }
+}

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/TokenPropagationTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/TokenPropagationTests.cs
@@ -59,6 +59,23 @@ public class TokenPropagationTests
         Assert.Equal(finalResponse.TotalTokens, completed.TotalTokens);
     }
 
+    [Fact]
+    public void ComputeTotalTokens_WhenOnlyCachedTokensAreProvided_ShouldReturnCachedValue()
+    {
+        var responseHelperType = typeof(AiSceneResponse).Assembly
+            .GetType("Rystem.PlayFramework.Services.Helpers.ResponseHelper");
+        Assert.NotNull(responseHelperType);
+
+        var computeTotalTokensMethod = responseHelperType!.GetMethod(
+            "ComputeTotalTokens",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(computeTotalTokensMethod);
+
+        var result = computeTotalTokensMethod!.Invoke(null, [null, null, 42]);
+
+        Assert.Equal(42, Assert.IsType<int>(result));
+    }
+
     private interface ITokenMathService
     {
         Task<double> AddAsync(double a, double b);


### PR DESCRIPTION
## What this PR does

This PR fixes token metric propagation in PlayFramework terminal events so business hooks can reliably persist usage at the end of an execution.

## Problem

OnTerminalScene hooks were receiving the terminal Completed item without token counters (InputTokens, OutputTokens, CachedInputTokens, TotalTokens), even when those values were present in the preceding final scene response.

As a result, usage persistence hooks could not track full token usage from the terminal event.

## Changes

- SceneManager
  - Updated terminal Completed response creation to copy token counters from the latest scene response.
  - Extended YieldStatus to accept and populate token fields.

- ResponseHelper hardening
  - CreateFinalResponse, CreateErrorResponse, and CreateAndTrackResponse now always set TotalTokens when any token component is available.
  - Added a centralized ComputeTotalTokens helper for consistent behavior.

- Tests
  - Added TokenPropagationTests to verify:
    - FinalResponse includes input/output/cached/total tokens.
    - Terminal Completed event carries the same token counters.

## Why this matters

This ensures usage tracking hooks can persist complete token telemetry from terminal events, avoiding data loss in cost and token accounting pipelines.

## Validation

- Ran targeted test successfully:
  - dotnet test src/AI/Test/Rystem.PlayFramework.Test/Rystem.PlayFramework.Test.csproj --filter FullyQualifiedName~TokenPropagationTests