### PR TITLE
fix(play-framework): fix context loss

### DIFF
--- a/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
+++ b/src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj
@@ -18,7 +18,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework.Adapters</RepositoryUrl>
         <PackageId>Rystem.PlayFramework.Adapters</PackageId>
-        <Version>10.0.11-beta.20</Version>
+        <Version>10.0.11-beta.21</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);OPENAI001;AOAI001</NoWarn>
@@ -45,7 +45,7 @@
         </When>
         <When Condition=" '$(Configuration)'!='Debug' ">
             <ItemGroup>
-                <PackageReference Include="Rystem.PlayFramework" Version="10.0.11-beta.14" />
+                <PackageReference Include="Rystem.PlayFramework" Version="10.0.11-beta.21" />
             </ItemGroup>
         </When>
     </Choose>

--- a/src/AI/Rystem.PlayFramework/Domain/Models/SceneContext.cs
+++ b/src/AI/Rystem.PlayFramework/Domain/Models/SceneContext.cs
@@ -392,9 +392,9 @@ public sealed class SceneContext
         {
             message.MarkAsSummarized();
         }
-        AddUserMessage(InputMessage);
         // Add summary message (has Message flag, will be sent to LLM)
         ConversationHistory.Add(TrackedMessage.CreateSummaryMessage(summary));
+        AddUserMessage(InputMessage);
     }
 
     /// <summary>

--- a/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
+++ b/src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj
@@ -18,7 +18,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/KeyserDSoze/Rystem/tree/master/src/AI/Rystem.PlayFramework</RepositoryUrl>
     <PackageId>Rystem.PlayFramework</PackageId>
-    <Version>10.0.11-beta.20</Version>
+    <Version>10.0.11-beta.21</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
+++ b/src/AI/Rystem.PlayFramework/Services/SceneManager.cs
@@ -400,6 +400,60 @@ internal sealed class SceneManager : ISceneManager, IFactoryName
             mainActorOutputs.Count, contextResult != null, _settings.Guardrails.Enabled, _factoryName);
     }
 
+    private async Task RefreshDynamicContextAsync(
+        SceneContext context,
+        CancellationToken cancellationToken)
+    {
+        if (_context == null)
+            return;
+
+        var contextSettings = new SceneRequestSettings { ConversationKey = context.ConversationKey };
+        var contextResult = await _context.RetrieveAsync(context, contextSettings, cancellationToken);
+        if (contextResult == null)
+            return;
+
+        var existingInitialContext = context.ConversationHistory
+            .FirstOrDefault(message => message.Label == "InitialContext")?
+            .Message
+            .Text;
+
+        context.BuildInitialContext(contextResult, ExtractSystemInstructions(existingInitialContext), _jsonService);
+
+        _logger.LogDebug("Dynamic context refreshed for cached conversation '{ConversationKey}' (Factory: {FactoryName})",
+            context.ConversationKey, _factoryName);
+    }
+
+    private static IEnumerable<string> ExtractSystemInstructions(string? initialContextText)
+    {
+        if (string.IsNullOrWhiteSpace(initialContextText))
+            return [];
+
+        var lines = initialContextText.Split('\n');
+        var instructions = new List<string>();
+        var inInstructionsSection = false;
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.TrimEnd('\r');
+            if (!inInstructionsSection)
+            {
+                inInstructionsSection = string.Equals(trimmedLine, "[System Instructions]", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (trimmedLine.StartsWith("- ", StringComparison.Ordinal))
+            {
+                instructions.Add(trimmedLine[2..]);
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(trimmedLine))
+                break;
+        }
+
+        return instructions;
+    }
+
     private async IAsyncEnumerable<AiSceneResponse> InitializePlayFrameworkAsync(SceneContext context,
         SceneRequestSettings settings,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -515,6 +569,11 @@ internal sealed class SceneManager : ISceneManager, IFactoryName
             });
             context.ExecutionPhase = ExecutionPhase.Break;
             yield break;
+        }
+
+        if (loadedFromStorageOrCache)
+        {
+            await RefreshDynamicContextAsync(context, cancellationToken);
         }
 
         // Detect if we're resuming from a client interaction batch

--- a/src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs
+++ b/src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs
@@ -406,6 +406,39 @@ public sealed class ConversationCacheTests
         Assert.Equal("User", context.ConversationHistory[3].Label);
     }
 
+    [Fact]
+    public void ApplySummary_ShouldPlaceSummaryBeforeCurrentUserInConversationAndLlmMessages()
+    {
+        // Arrange
+        var context = new SceneContext
+        {
+            ServiceProvider = null!,
+            Input = MultiModalInput.FromText("confermo"),
+            ChatClientManager = null!
+        };
+
+        context.BuildInitialContext(new { Now = "2026-06-11T17:04:50" }, ["Timesheet assistant"]);
+        context.AddUserMessage("Ho inserito 4 ore sul progetto Z dal 18 al 21 aprile.");
+        context.AddAssistantMessage(new ChatMessage(ChatRole.Assistant, "Vuoi confermare l'inserimento?"));
+        context.AddUserMessage(context.Input);
+
+        // Act
+        context.ApplySummary("L'utente ha inserito 4 ore sul progetto Z e ora sta confermando.");
+
+        // Assert
+        var summaryIndex = context.ConversationHistory.FindIndex(m => m.Label == "Summary");
+        var currentUserIndex = context.ConversationHistory.FindLastIndex(m => m.Label == "User" && m.IsActiveMessage);
+
+        Assert.True(summaryIndex >= 0);
+        Assert.True(currentUserIndex > summaryIndex);
+
+        var messagesForLlm = context.GetMessagesForLLM();
+        Assert.Equal(3, messagesForLlm.Count);
+        Assert.Contains("[Request Context]", messagesForLlm[0].Text);
+        Assert.Contains("[Previous conversation summary]", messagesForLlm[1].Text);
+        Assert.Equal("confermo", messagesForLlm[2].Text);
+    }
+
     #endregion
 
     #region Integration Tests (full pipeline with cache)
@@ -521,7 +554,148 @@ public sealed class ConversationCacheTests
         Assert.DoesNotContain(capturedMessages, m => m.Contains("Do not repeat already completed actions"));
     }
 
+    [Fact]
+    public async Task SecondTurn_WhenSummarizationRuns_ShouldSendSummaryBeforeCurrentUser()
+    {
+        // Arrange
+        var capturedMessages = new List<string>();
+        var services = new ServiceCollection();
+        services.AddLogging(logging => logging.SetMinimumLevel(LogLevel.Debug));
+        services.AddDistributedMemoryCache();
+        services.AddChatClient<CapturingMockChatClient>(name: null);
+        services.AddSingleton(capturedMessages);
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.AddScene("TestScene", "A test scene", _ => { });
+            builder.AddCustomSummarizer<FixedSummarySummarizer>();
+            builder.WithSummarization(settings => settings.ResponseCountThreshold = 2);
+            builder.AddCache(cacheBuilder =>
+            {
+                cacheBuilder.WithDistributed().WithExpiration(TimeSpan.FromMinutes(5));
+            });
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var sceneManager = serviceProvider.GetRequiredService<ISceneManager>();
+
+        var conversationKey = Guid.NewGuid().ToString();
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Direct,
+            ConversationKey = conversationKey
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("Ho inserito 4 ore sul progetto Z", metadata: null, settings)) { }
+        capturedMessages.Clear();
+
+        // Act
+        await foreach (var _ in sceneManager.ExecuteAsync("confermo", metadata: null, settings)) { }
+
+        // Assert
+        var summaryIndex = capturedMessages.FindIndex(message => message.Contains("[Previous conversation summary]"));
+        var currentUserIndex = capturedMessages.FindIndex(message => message == "confermo");
+
+        Assert.True(summaryIndex >= 0);
+        Assert.True(currentUserIndex > summaryIndex);
+    }
+
+    [Fact]
+    public async Task SecondTurn_WithCachedConversation_ShouldRefreshInitialContext()
+    {
+        // Arrange
+        var capturedMessages = new List<string>();
+        var contextSequence = new SequentialContextState(
+            new ContextSnapshot("first", "2026-06-11T17:04:50"),
+            new ContextSnapshot("second", "2026-06-12T09:15:00"));
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging => logging.SetMinimumLevel(LogLevel.Debug));
+        services.AddDistributedMemoryCache();
+        services.AddChatClient<CapturingMockChatClient>(name: null);
+        services.AddSingleton(capturedMessages);
+        services.AddSingleton(contextSequence);
+
+        services.AddPlayFramework(builder =>
+        {
+            builder.AddScene("TestScene", "A test scene", _ => { });
+            builder.AddMainActor("Always preserve this instruction");
+            builder.AddContext<SequentialContextProvider>();
+            builder.AddCache(cacheBuilder =>
+            {
+                cacheBuilder.WithDistributed().WithExpiration(TimeSpan.FromMinutes(5));
+            });
+        });
+
+        var serviceProvider = services.BuildServiceProvider();
+        var sceneManager = serviceProvider.GetRequiredService<ISceneManager>();
+
+        var conversationKey = Guid.NewGuid().ToString();
+        var settings = new SceneRequestSettings
+        {
+            ExecutionMode = SceneExecutionMode.Direct,
+            ConversationKey = conversationKey
+        };
+
+        await foreach (var _ in sceneManager.ExecuteAsync("Primo turno", metadata: null, settings)) { }
+        capturedMessages.Clear();
+
+        // Act
+        await foreach (var _ in sceneManager.ExecuteAsync("Secondo turno", metadata: null, settings)) { }
+
+        // Assert
+        Assert.Equal(2, contextSequence.CallCount);
+
+        var initialContext = Assert.Single(capturedMessages, message => message.Contains("[Request Context]"));
+        Assert.Contains("\"marker\":\"second\"", initialContext);
+        Assert.DoesNotContain("\"marker\":\"first\"", initialContext);
+        Assert.Contains("Always preserve this instruction", initialContext);
+    }
+
     #endregion
+}
+
+internal sealed class FixedSummarySummarizer : ISummarizer
+{
+    public bool ShouldSummarize(List<AiSceneResponse> responses) => true;
+
+    public Task<string> SummarizeAsync(List<AiSceneResponse> responses, CancellationToken cancellationToken = default)
+        => Task.FromResult("Summary generated for cached conversation.");
+}
+
+internal sealed record ContextSnapshot(string Marker, string Now);
+
+internal sealed class SequentialContextState
+{
+    private readonly Queue<ContextSnapshot> _snapshots;
+
+    public SequentialContextState(params ContextSnapshot[] snapshots)
+    {
+        _snapshots = new Queue<ContextSnapshot>(snapshots);
+    }
+
+    public int CallCount { get; private set; }
+
+    public ContextSnapshot Next()
+    {
+        CallCount++;
+        return _snapshots.TryDequeue(out var snapshot)
+            ? snapshot
+            : throw new InvalidOperationException("No more context snapshots available for the test.");
+    }
+}
+
+internal sealed class SequentialContextProvider : IContext
+{
+    private readonly SequentialContextState _state;
+
+    public SequentialContextProvider(SequentialContextState state)
+    {
+        _state = state;
+    }
+
+    public Task<object?> RetrieveAsync(SceneContext context, SceneRequestSettings settings, CancellationToken cancellationToken)
+        => Task.FromResult<object?>(_state.Next());
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary
This PR fixes two context-related issues in `Rystem.PlayFramework` that could degrade multi-turn behavior after cache resume and conversation summarization.

## Why this change
In long-running conversations, two edge cases could reduce response quality:

1. **Summary ordering during compaction**
   - When summarization is triggered, resumable messages are compacted.
   - The current user input was appended **before** the generated summary.
   - This allowed the model to read a short user reply without first reading the summarized context.

2. **Stale initial context on cached turns**
   - For resumed conversations loaded from cache/repository, initialization was skipped entirely.
   - The initial context message could keep outdated dynamic values (for example, time-sensitive fields) across subsequent turns.

## What changed

### 1) Fix summary ordering
- File: `src/AI/Rystem.PlayFramework/Domain/Models/SceneContext.cs`
- Method: `ApplySummary(string summary)`
- Change:
  - Keep marking resumable messages as summarized.
  - Append `Summary` message **before** re-adding the current user message.

Result: the model now receives compacted context before interpreting the current short user reply.

### 2) Refresh only dynamic context for cached conversations
- File: `src/AI/Rystem.PlayFramework/Services/SceneManager.cs`
- Added:
  - `RefreshDynamicContextAsync(...)`
  - `ExtractSystemInstructions(...)`
- Flow update:
  - When a conversation is loaded from cache/repository, refresh dynamic context via `IContext.RetrieveAsync(...)`.
  - Rebuild `InitialContext` using fresh context data while preserving previously cached system instruction lines.
  - Avoid re-running expensive/static initialization paths.

Result: resumed turns keep dynamic context values current without redoing static setup.

### 3) Tests added
- File: `src/AI/Test/Rystem.PlayFramework.Test/Tests/ConversationCacheTests.cs`
- New coverage:
  - `ApplySummary_ShouldPlaceSummaryBeforeCurrentUserInConversationAndLlmMessages`
  - `SecondTurn_WhenSummarizationRuns_ShouldSendSummaryBeforeCurrentUser`
  - `SecondTurn_WithCachedConversation_ShouldRefreshInitialContext`

These tests verify both message ordering and dynamic context refresh behavior across cached turns.

### 4) Package version bump
- `src/AI/Rystem.PlayFramework/Rystem.PlayFramework.csproj`
  - `10.0.11-beta.20` -> `10.0.11-beta.21`
- `src/AI/Rystem.PlayFramework.Adapters/Rystem.PlayFramework.Adapters.csproj`
  - `10.0.11-beta.20` -> `10.0.11-beta.21`
  - Adapter package reference aligned to `Rystem.PlayFramework 10.0.11-beta.21`

## Validation
Executed:
- `dotnet test --filter "FullyQualifiedName~ConversationCacheTests"`

Outcome:
- All targeted tests passed, including new regression tests.

## Impact
- Improves robustness of multi-turn conversations when summarization and cache resume are active.
- Reduces risk of context drift on resumed conversations.
- Backward-compatible behavior with focused internal changes and regression coverage.